### PR TITLE
Amazon Linux 1 support

### DIFF
--- a/bash/install/falcon-linux-install.sh
+++ b/bash/install/falcon-linux-install.sh
@@ -455,7 +455,7 @@ cs_os_version=$(
     version=$(echo "$os_version" | awk -F'.' '{print $1}')
     if [ "$cs_os_arch" = "aarch64" ] ; then
         echo "$os_version - arm64"
-    elif [ "$os_name" = "Amazon" ] && [ "$version" -ge 2011 ] ; then
+    elif [ "$os_name" = "Amazon" ] && [ "$version" -ge 2017 ] ; then
       echo "1"
     else
         echo "$version"

--- a/bash/install/falcon-linux-install.sh
+++ b/bash/install/falcon-linux-install.sh
@@ -456,7 +456,7 @@ cs_os_version=$(
     if [ "$cs_os_arch" = "aarch64" ] ; then
         echo "$os_version - arm64"
     elif [ "$os_name" = "Amazon" ] && [ "$version" -ge 2017 ] ; then
-      echo "1"
+        echo "1"
     else
         echo "$version"
     fi

--- a/bash/install/falcon-linux-install.sh
+++ b/bash/install/falcon-linux-install.sh
@@ -397,7 +397,7 @@ cs_uninstall=$(
 os_name=$(
     # returns either: Amazon, Ubuntu, CentOS, RHEL, or SLES
     # lsb_release is not always present
-    name=$(cat /etc/*release | grep ^NAME= | awk -F'=' '{ print $2 }' | sed "s/\"//g;s/Red Hat.*/RHEL/g;s/ Linux$//g;s/ GNU\/Linux$//g;s/Oracle.*/Oracle/g")
+    name=$(cat /etc/*release | grep ^NAME= | awk -F'=' '{ print $2 }' | sed "s/\"//g;s/Red Hat.*/RHEL/g;s/ Linux$//g;s/ GNU\/Linux$//g;s/Oracle.*/Oracle/g;s/Amazon.*/Amazon/g")
     if [ -z "$name" ]; then
         if lsb_release -s -i | grep -q ^RedHat; then
             name="RHEL"
@@ -455,6 +455,8 @@ cs_os_version=$(
     version=$(echo "$os_version" | awk -F'.' '{print $1}')
     if [ "$cs_os_arch" = "aarch64" ] ; then
         echo "$os_version - arm64"
+    elif [ "$os_name" = "Amazon" ] && [ "$version" -ge 2011 ] ; then
+      echo "1"
     else
         echo "$version"
     fi


### PR DESCRIPTION
Two changes are required - one to recognize the OS name and another to convert the Amazon Linux version to mapping recognized by the Falcon sensor.
Amazon has versions like 2018.03 for Amazon Linux 1