### PR TITLE
Added if statement to check if instance is aws

### DIFF
--- a/bash/install/falcon-linux-install.sh
+++ b/bash/install/falcon-linux-install.sh
@@ -31,11 +31,8 @@ main() {
 }
 
 cs_sensor_register() {
-    if [ -z "${cs_falcon_cid}" ]; then
-        cs_target_cid=$(curl -s -L "https://$(cs_cloud)/sensors/queries/installers/ccid/v1" \
-                             -H "authorization: Bearer $cs_falcon_oauth_token")
-
-        cs_falcon_cid=$(echo "$cs_target_cid" | tr -d '\n" ' | awk -F'[][]' '{print $2}')
+    if [ -z "$cs_falcon_cid" ]; then
+        die "Could not find FALCON CID!"
     fi
 
     cs_falcon_args=--cid="${cs_falcon_cid}"
@@ -495,14 +492,6 @@ cs_falcon_client_secret=$(
     fi
 )
 
-cs_falcon_cid=$(
-    if [ -n "$FALCON_CID" ]; then
-        echo "$FALCON_CID"
-    elif [ -n "$aws_instance" ]; then
-        aws_ssm_parameter "FALCON_CID" | json_value Value 1
-    fi
-)
-
 cs_falcon_token=$(
     if [ -n "$FALCON_PROVISIONING_TOKEN" ]; then
         echo "$FALCON_PROVISIONING_TOKEN"
@@ -557,6 +546,17 @@ cs_falcon_oauth_token=$(
         die "Unable to obtain CrowdStrike Falcon OAuth Token. Response was $token_result"
     fi
     echo "$token"
+)
+
+cs_falcon_cid=$(
+    if [ -n "$FALCON_CID" ]; then
+        echo "$FALCON_CID"
+    else
+        cs_target_cid=$(curl -s -L "https://$(cs_cloud)/sensors/queries/installers/ccid/v1" \
+                                -H "authorization: Bearer $cs_falcon_oauth_token")
+
+        echo "$cs_target_cid" | tr -d '\n" ' | awk -F'[][]' '{print $2}'
+    fi
 )
 
 region_hint=$(grep -i ^x-cs-region: "$response_headers" | head -n 1 | tr '[:upper:]' '[:lower:]' | tr -d '\r' | sed 's/^x-cs-region: //g')

--- a/bash/install/falcon-linux-install.sh
+++ b/bash/install/falcon-linux-install.sh
@@ -498,7 +498,7 @@ cs_falcon_client_secret=$(
 cs_falcon_cid=$(
     if [ -n "$FALCON_CID" ]; then
         echo "$FALCON_CID"
-    else
+    elif [ -n "$aws_instance" ]; then
         aws_ssm_parameter "FALCON_CID" | json_value Value 1
     fi
 )


### PR DESCRIPTION
After chatting with @redhatrises  - this issue was an oversight when copying over from the functionality from another script. There are 2 options that we can use to fix this:

1. The current fix simply ensures that we don't call the `aws_ssm_parameter` function unless it's an `aws_instance`. 
2. Or..rather than use the `aws_instance` variable check, we can opt to use an environmental variable such as `FALCON_AWS_SSM      (default: false)`, and then call the `aws_ssm_parameter` function when this env variable is true.

I'm open to suggestions.