### PR TITLE
Move the cs_falcon_cid after the region check

### DIFF
--- a/bash/install/falcon-linux-install.sh
+++ b/bash/install/falcon-linux-install.sh
@@ -548,17 +548,6 @@ cs_falcon_oauth_token=$(
     echo "$token"
 )
 
-cs_falcon_cid=$(
-    if [ -n "$FALCON_CID" ]; then
-        echo "$FALCON_CID"
-    else
-        cs_target_cid=$(curl -s -L "https://$(cs_cloud)/sensors/queries/installers/ccid/v1" \
-                                -H "authorization: Bearer $cs_falcon_oauth_token")
-
-        echo "$cs_target_cid" | tr -d '\n" ' | awk -F'[][]' '{print $2}'
-    fi
-)
-
 region_hint=$(grep -i ^x-cs-region: "$response_headers" | head -n 1 | tr '[:upper:]' '[:lower:]' | tr -d '\r' | sed 's/^x-cs-region: //g')
 rm "${response_headers}"
 
@@ -572,5 +561,16 @@ else
         echo "WARNING: FALCON_CLOUD='${FALCON_CLOUD}' environment variable specified while credentials only exists in '${region_hint}'" >&2
     fi
 fi
+
+cs_falcon_cid=$(
+    if [ -n "$FALCON_CID" ]; then
+        echo "$FALCON_CID"
+    else
+        cs_target_cid=$(curl -s -L "https://$(cs_cloud)/sensors/queries/installers/ccid/v1" \
+                                -H "authorization: Bearer $cs_falcon_oauth_token")
+
+        echo "$cs_target_cid" | tr -d '\n" ' | awk -F'[][]' '{print $2}'
+    fi
+)
 
 main "$@"


### PR DESCRIPTION
Actually the deployment in other region is not working (US-1 is the main region), The CID is computed before the region checks which generate this error:

`Falcon Sensor Install  ... [ Ok ]
Falcon Sensor Register ... "{code:401,message:accessdenied,invalidbearertoken}" failed checksum validation
ERROR: failed to process the option --cid
Usage: falconctl -g GET_OPTIONS
       falconctl -s [ -f ] SET_OPTIONS
       falconctl -d [ -f ] DEL_OPTIONS
where GET_OPTIONS := { --cid for CustomerId |
`

So the sensor is downloaded but the CID is not set due to the compute done before the region check.

This PR fix this issue.