### PR TITLE
API for RHEL/.. os filter is inconsistent

### DIFF
--- a/bash/install/falcon-linux-install.sh
+++ b/bash/install/falcon-linux-install.sh
@@ -435,7 +435,7 @@ cs_os_name=$(
         Amazon)
             echo "Amazon Linux";;
         CentOS|Oracle|RHEL|Rocky|AlmaLinux)
-            echo "RHEL/CentOS/Oracle";;
+            echo "*RHEL*";;
         Debian)
             echo "Debian";;
         SLES)


### PR DESCRIPTION
This PR fixes an issue affecting RHEL family only. For RHEL based systems, you can see a few different variations for the`os:` output of the sensor query. This ensures we capture any RHEL based os version to ensure we account for RHEL 9, arm, and x64.

Example filter w/ change:
```
'filter=os:"*RHEL*"+os_version:~"arm64"'
```

This is also consistent with Ansible/Puppet/Chef