### PR TITLE
Powershell - Uninstall script major updates

### DIFF
--- a/powershell/install/README.md
+++ b/powershell/install/README.md
@@ -7,8 +7,12 @@ Powershell scripts to install/uninstall Falcon Sensor through the Falcon APIs on
 API clients are granted one or more API scopes. Scopes allow access to specific CrowdStrike APIs and describe the actions that an API client can perform.
 
 Ensure the following API scopes are enabled:
-* **Sensor Download** [read]
-* **Sensor update policies** [read]
+- Install:
+  * **Sensor Download** [read]
+  * **Sensor update policies** [read]
+- Uninstall:
+  * **Host** [write]
+  * **Sensor update policies** [write]
 
 ## Configuration
 
@@ -66,7 +70,8 @@ the parameter descriptions:
 
 ```pwsh
 .PARAMETER MaintenanceToken
-Sensor uninstall maintenance token ['https://api.crowdstrike.com' if left undefined]
+Sensor uninstall maintenance token. If left undefined, the script will attempt to retrieve the
+token from the API assuming the FalconClientId|FalconClientSecret are defined.
 .PARAMETER UninstallParams
 Sensor uninstall parameters ['/uninstall /quiet' if left undefined]
 .PARAMETER UninstallTool
@@ -77,9 +82,27 @@ Script log location ['Windows\Temp\csfalcon_uninstall.log' if left undefined]
 Delete sensor uninstaller package when complete [default: $true]
 .PARAMETER DeleteScript
 Delete script when complete [default: $true]
+.PARAMETER RemoveHost
+Remove host from CrowdStrike Falcon [default: $false]
+.PARAMETER FalconCloud
+CrowdStrike Falcon OAuth2 API Hostname [default: autodiscover]
+.PARAMETER FalconClientId
+CrowdStrike Falcon OAuth2 API Client Id [Required if RemoveHost is $true]
+.PARAMETER FalconClientSecret
+CrowdStrike Falcon OAuth2 API Client Secret [Required if RemoveHost is $true]
+.PARAMETER MemberCid
+Member CID, used only in multi-CID ("Falcon Flight Control") configurations and with a parent management CID.
 ```
 
-Example:
+Examples:
+
+Basic example that will uninstall the sensor with the provided maintenance token
 ```pwsh
 PS>.\falcon_windows_uninstall.ps1 -MaintenanceToken <string>
+```
+
+An example using the Falcon API to retrieve the maintenance token and remove the host from the Falcon console
+after uninstalling.
+```pwsh
+PS>.\falcon_windows_uninstall.ps1 -FalconClientId <string> -FalconClientSecret <string> -RemoveHost $true
 ```

--- a/powershell/install/falcon_windows_uninstall.ps1
+++ b/powershell/install/falcon_windows_uninstall.ps1
@@ -233,7 +233,7 @@ begin {
         }
         return $Message
     }
-    
+
     function Format-FalconResponseError($errors) {
         $Message = ""
         foreach ($error in $errors) {

--- a/powershell/install/falcon_windows_uninstall.ps1
+++ b/powershell/install/falcon_windows_uninstall.ps1
@@ -13,7 +13,7 @@ The script must be run as an administrator on the local machine in order for the
 uninstall and the OAuth2 API Client being used requires 'sensor-update-policies:write' and
 'host:write' permissions.
 .PARAMETER MaintenanceToken
-Sensor uninstall maintenance token ['https://api.crowdstrike.com' if left undefined]
+Sensor uninstall maintenance token. If left undefined, the script will attempt to retrieve the token from the API assuming the FalconClientId|FalconClientSecret are defined.
 .PARAMETER UninstallParams
 Sensor uninstall parameters ['/uninstall /quiet' if left undefined]
 .PARAMETER UninstallTool
@@ -37,11 +37,12 @@ Member CID, used only in multi-CID ("Falcon Flight Control") configurations and 
 .EXAMPLE
 PS>.\falcon_windows_uninstall.ps1 -MaintenanceToken <string>
 
-All parameters will use their default values.
+Uninstall the Falcon sensor with the provided MaintenanceToken.
 .EXAMPLE
-PS>.\falcon_windows_uninstall.ps1
+PS>.\falcon_windows_uninstall.ps1 -FalconClientId <string> -FalconClientSecret <string> -RemoveHost $true
 
-Run the script and use all values that were previously defined within the script.
+Use the Falcon API to retrieve the maintenance token and remove the host from the Falcon console
+after uninstalling.
 #>
 [CmdletBinding()]
 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'DeleteUninstaller')]

--- a/powershell/install/falcon_windows_uninstall.ps1
+++ b/powershell/install/falcon_windows_uninstall.ps1
@@ -473,10 +473,6 @@ process {
         throw $Message
     }
 
-    if ($RemoveHost) {
-
-    }
-
     @('DeleteUninstaller', 'DeleteScript') | ForEach-Object {
         if ((Get-Variable $_).Value -eq $true) {
             $FilePath = if ($_ -eq 'DeleteUninstaller') {

--- a/powershell/install/falcon_windows_uninstall.ps1
+++ b/powershell/install/falcon_windows_uninstall.ps1
@@ -409,7 +409,7 @@ process {
                 Write-FalconLog $null "Host already removed from CrowdStrike Falcon"
             } elseif ($response.StatusCode -eq 403) {
                 $scope = @{
-                    "host" = @("Write")
+                    "host" = @("Write", "Read")
                 }
                 $Message = New-403Error -url $url -scope $scope
                 Write-FalconLog "RemoveHostError" $Message


### PR DESCRIPTION
This PR addresses the following issues:

- #103 
  - Adds support to retrieve the uninstall/maintenance token from the API.
  - This should make it easier when uninstalling multiple systems w/o using a bulk maintenance token. 
- #104 
  - Adds the ability to hide (send to trash) the host from the Falcon console UI. 
  - This provides the ability to prevent duplicate hosts on the Falcon console, as well as an easy way to keep the console clean.
- Added API authentication support
- Added error code handling to provide better messaging
- Added the ability to get the AID

Co-authored: @carlosmmatos 