### PR TITLE
Adding workflow to add scripts as artifacts to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Release artifacts to GitHub
+        run: |
+          list_of_files=$(find . -type f | egrep '\.sh|\.ps1')
+          gh release upload $TAG $list_of_files
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+


### PR DESCRIPTION
Closes #114 

Add a GH action to automate uploading script artifacts to a release.