### PR TITLE
Adds newly added env var for legacy curl check

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -29,6 +29,7 @@ jobs:
       ANSIBLE_FORCE_COLOR: 1
       FALCON_CLIENT_ID: ${{ secrets.FALCON_CLIENT_ID }}
       FALCON_CLIENT_SECRET: ${{ secrets.FALCON_CLIENT_SECRET }}
+      ALLOW_LEGACY_CURL: 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -29,7 +29,6 @@ jobs:
       ANSIBLE_FORCE_COLOR: 1
       FALCON_CLIENT_ID: ${{ secrets.FALCON_CLIENT_ID }}
       FALCON_CLIENT_SECRET: ${{ secrets.FALCON_CLIENT_SECRET }}
-      ALLOW_LEGACY_CURL: 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/molecule/bash_install/converge.yml
+++ b/molecule/bash_install/converge.yml
@@ -6,6 +6,7 @@
   environment:
     FALCON_CLIENT_ID: "{{ lookup('env', 'FALCON_CLIENT_ID') }}"
     FALCON_CLIENT_SECRET: "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}"
+    ALLOW_LEGACY_CURL: "true"
   tasks:
     # Execute shell command
     - name: Install Falcon Sensor

--- a/molecule/bash_install_decrement/converge.yml
+++ b/molecule/bash_install_decrement/converge.yml
@@ -7,6 +7,7 @@
     FALCON_CLIENT_ID: "{{ lookup('env', 'FALCON_CLIENT_ID') }}"
     FALCON_CLIENT_SECRET: "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}"
     FALCON_SENSOR_VERSION_DECREMENT: '2'
+    ALLOW_LEGACY_CURL: "true"
   tasks:
     # Execute shell command
     - name: Install Falcon Sensor

--- a/molecule/bash_install_only/converge.yml
+++ b/molecule/bash_install_only/converge.yml
@@ -7,6 +7,7 @@
     FALCON_CLIENT_ID: "{{ lookup('env', 'FALCON_CLIENT_ID') }}"
     FALCON_CLIENT_SECRET: "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}"
     FALCON_INSTALL_ONLY: 'true'
+    ALLOW_LEGACY_CURL: "true"
   tasks:
     # Execute shell command
     - name: Install Falcon Sensor

--- a/molecule/bash_install_policy/converge.yml
+++ b/molecule/bash_install_policy/converge.yml
@@ -7,6 +7,7 @@
     FALCON_CLIENT_ID: "{{ lookup('env', 'FALCON_CLIENT_ID') }}"
     FALCON_CLIENT_SECRET: "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}"
     FALCON_SENSOR_UPDATE_POLICY_NAME: "platform_default"
+    ALLOW_LEGACY_CURL: "true"
   tasks:
     # Execute shell command
     - name: Install Falcon Sensor


### PR DESCRIPTION
Based on #157 fix - this allows the centos7 workflow to run since that uses a legacy version of curl.