### PR TITLE
Fix molecule issues

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           sudo apt install apt-transport-https ca-certificates curl software-properties-common libssl-dev
           python -m pip install --upgrade pip
-          pip install molecule "molecule-plugins[docker]" ansible ansible-core ansible-lint
+          pip install molecule "molecule-plugins[docker]" ansible ansible-core ansible-lint "requests<2.30.0"
 
       - name: Run integration tests
         uses: nick-fields/retry@v2

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.swo
 *~
 *DS_Store
+.vagrant

--- a/molecule/pwsh_install_ccid/molecule.yml
+++ b/molecule/pwsh_install_ccid/molecule.yml
@@ -8,7 +8,6 @@ driver:
 platforms:
   - name: falcon
     box: "jborean93/${MOLECULE_DISTRO:-WindowsServer2019}"
-    box_version: 1.0.0
     memory: 4096
     cpus: 2
 provisioner:

--- a/molecule/pwsh_install_policy/converge.yml
+++ b/molecule/pwsh_install_policy/converge.yml
@@ -3,8 +3,8 @@
   hosts: all
   tasks:
     - name: Run Install Script
-      ansible.builtin.script: |
-        ../../powershell/install/falcon_windows_install.ps1 `
-        -FalconClientId "{{ lookup('env', 'FALCON_CLIENT_ID') }}" `
-        -FalconClientSecret "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}" `
+      ansible.builtin.script: >
+        ../../powershell/install/falcon_windows_install.ps1
+        -FalconClientId "{{ lookup('env', 'FALCON_CLIENT_ID') }}"
+        -FalconClientSecret "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}"
         -ProvToken "{{ lookup('env', 'FALCON_PROV_TOKEN') }}"

--- a/molecule/pwsh_install_policy/molecule.yml
+++ b/molecule/pwsh_install_policy/molecule.yml
@@ -8,7 +8,6 @@ driver:
 platforms:
   - name: falcon
     box: "jborean93/${MOLECULE_DISTRO:-WindowsServer2019}"
-    box_version: 1.0.0
     memory: 4096
     cpus: 2
 provisioner:

--- a/molecule/pwsh_migrate/molecule.yml
+++ b/molecule/pwsh_migrate/molecule.yml
@@ -8,7 +8,6 @@ driver:
 platforms:
   - name: falcon
     box: "jborean93/${MOLECULE_DISTRO:-WindowsServer2019}"
-    box_version: 1.0.0
     memory: 8192
     cpus: 3
 provisioner:


### PR DESCRIPTION
Recent changes to vagrant boxes and molecule plugins have caused the windows CI jobs to fail.