### PR TITLE
Allowing proper use of member_cid if requested

### DIFF
--- a/powershell/install/falcon_windows_install.ps1
+++ b/powershell/install/falcon_windows_install.ps1
@@ -333,6 +333,8 @@ process {
 
     if ($MemberCid) {
         $ApiClient["&member_cid"] = $MemberCid
+        # If MemberCid is provided, override FalconCid
+        $FalconCid = $MemberCid
     }
 
     Invoke-FalconAuth $ApiClient

--- a/powershell/migrate/falcon_windows_migrate.ps1
+++ b/powershell/migrate/falcon_windows_migrate.ps1
@@ -1039,6 +1039,10 @@ Write-MigrateLog 'Creating recovery csv to keep track of tags...'
 Write-RecoveryCsv -SensorGroupingTags $sensorGroupingTags -FalconGroupingTags $falconGroupingTags -OldAid $oldAid -Path $recoveryCsvPath
 
 Invoke-FalconUninstall -UninstallParams $UninstallParams -RemoveHost $RemoveHost -DeleteUninstaller $DeleteUninstaller -MaintenanceToken $MaintenanceToken -UninstallTool $UninstallTool
+# If NewMemberCid is defined, set that as NewFalconCid
+if (![string]::IsNullOrWhiteSpace($NewMemberCid)) {
+    $NewFalconCid = $NewMemberCid
+}
 Invoke-FalconInstall -InstallParams $InstallParams -Tags ($SensorGroupingTags -join ',') -DeleteInstaller $DeleteInstaller -SensorUpdatePolicyName $SensorUpdatePolicyName -ProvToken $ProvToken -ProvWaitTime $ProvWaitTime -NewFalconCid $NewFalconCid
 
 $timeout = Get-Date


### PR DESCRIPTION
Fixes #158 

If a MemberCID is provided, use that as the CID for provisioning a new instance. 