### PR TITLE
PowerShell install script enhancements

### DIFF
--- a/powershell/install/falcon_windows_install.ps1
+++ b/powershell/install/falcon_windows_install.ps1
@@ -119,13 +119,11 @@ begin {
 
         "$(@($Content + $Source) -join ' '): $Message" | Out-File -FilePath $LogPath -Append -Encoding utf8
 
-        if ([string]::IsNullOrEmpty($Source)) {
-            if ($FalconClientId.Length -gt 0) {
-                Write-Output $Message.replace($FalconClientId, '***')
-            }
-            else {
-                Write-Output $Message
-            }
+        if ($FalconClientId.Length -gt 0) {
+            Write-Output $Message.replace($FalconClientId, '***')
+        }
+        else {
+            Write-Output $Message
         }
     }
 
@@ -148,8 +146,8 @@ begin {
             $content = ConvertFrom-Json -InputObject $response.Content
 
             if ([string]::IsNullOrEmpty($content.access_token)) {
-                $Message = 'Unable to authenticate to the CrowdStrike Falcon API. Please check your credentials and try again.'
-                throw $Message
+                $message = 'Unable to authenticate to the CrowdStrike Falcon API. Please check your credentials and try again.'
+                throw $message
             }
 
             $Headers.Add('Authorization', "bearer $($content.access_token)")
@@ -159,9 +157,9 @@ begin {
             $response = $_.Exception.Response
 
             if (!$response) {
-                $Message = "Unhandled error occurred while authenticating to the CrowdStrike Falcon API. Error: $($_.Exception.Message)"
-                Write-FalconLog -Source 'Invoke-FalconAuth' -Message $Message
-                throw $Message
+                $message = "Unhandled error occurred while authenticating to the CrowdStrike Falcon API. Error: $($_.Exception.Message)"
+                Write-FalconLog -Source 'Invoke-FalconAuth' -Message $message
+                throw $message
             }
 
             if ($response.StatusCode -in @(301, 302, 303, 307, 308)) {
@@ -171,9 +169,9 @@ begin {
                         $region = $response.Headers.GetValues('X-Cs-Region')[0]
                     }
                     else {
-                        $Message = 'Received a redirect but no X-Cs-Region header was provided. Unable to autodiscover the FalconCloud. Please set FalconCloud to the correct region.'
-                        Write-FalconLog -Source 'Invoke-FalconAuth' -Message $Message
-                        throw $Message
+                        $message = 'Received a redirect but no X-Cs-Region header was provided. Unable to autodiscover the FalconCloud. Please set FalconCloud to the correct region.'
+                        Write-FalconLog -Source 'Invoke-FalconAuth' -Message $message
+                        throw $message
                     }
 
                     $BaseUrl = Get-FalconCloud($region)
@@ -181,15 +179,15 @@ begin {
 
                 }
                 else {
-                    $Message = "Received a redirect. Please set FalconCloud to 'autodiscover' or the correct region."
-                    Write-FalconLog -Source 'Invoke-FalconAuth' -Message $Message
-                    throw $Message
+                    $message = "Received a redirect. Please set FalconCloud to 'autodiscover' or the correct region."
+                    Write-FalconLog -Source 'Invoke-FalconAuth' -Message $message
+                    throw $message
                 }
             }
             else {
-                $Message = "Received a $($response.StatusCode) response from $($BaseUrl)oauth2/token. Please check your credentials and try again. Error: $($response.StatusDescription)"
-                Write-FalconLog -Source 'Invoke-FalconAuth' -Message $Message
-                throw $Message
+                $message = "Received a $($response.StatusCode) response from $($BaseUrl)oauth2/token. Please check your credentials and try again. Error: $($response.StatusDescription)"
+                Write-FalconLog -Source 'Invoke-FalconAuth' -Message $message
+                throw $message
             }
         }
 
@@ -212,19 +210,19 @@ begin {
     }
 
     function Format-403Error([string] $url, [hashtable] $scope) {
-        $Message = "Insufficient permission error when calling $($url). Verify the following scopes are included in the API key:"
+        $message = "Insufficient permission error when calling $($url). Verify the following scopes are included in the API key:"
         foreach ($key in $scope.Keys) {
-            $Message += "`r`n`t '$($key)' with: $($scope[$key])"
+            $message += "`r`n`t '$($key)' with: $($scope[$key])"
         }
-        return $Message
+        return $message
     }
 
     function Format-FalconResponseError($errors) {
-        $Message = ''
+        $message = ''
         foreach ($error in $errors) {
-            $Message += "`r`n`t $($error.message)"
+            $message += "`r`n`t $($error.message)"
         }
-        return $Message
+        return $message
     }
 
     function Get-ResourceContent([string] $url, [string] $logKey, [hashtable] $scope, [string] $errorMessage) {
@@ -236,7 +234,7 @@ begin {
                 $message = "Error when getting content: "
                 $message += Format-FalconResponseError -errors $content.errors
                 Write-FalconLog $logKey $message
-                throw $Message
+                throw $message
             }
 
             if ($content.resources) {
@@ -265,7 +263,6 @@ begin {
             else {
                 $message = "Received a $($response.StatusCode) response from ${url}. Error: $($response.StatusDescription)"
                 Write-FalconLog $logKey $message
-                Write-Host $message
                 throw $message
             }
         }
@@ -293,9 +290,9 @@ begin {
         catch {
             $response = $_.Exception.Response
             if (!$response) {
-                $Message = "Unhandled error occurred. Error: $($_.Exception.Message)"
-                Write-FalconLog 'DownloadFile' $Message
-                throw $Message
+                $message = "Unhandled error occurred. Error: $($_.Exception.Message)"
+                Write-FalconLog 'DownloadFile' $message
+                throw $message
             }
             if ($response.StatusCode -eq 403) {
                 $scope = @{
@@ -306,9 +303,9 @@ begin {
                 throw $message
             }
             else {
-                $Message = "Received a $($response.StatusCode) response from ${url}. Error: $($response.StatusDescription)"
-                Write-FalconLog 'DownloadFile' $Message
-                throw $Message
+                $message = "Received a $($response.StatusCode) response from ${url}. Error: $($response.StatusDescription)"
+                Write-FalconLog 'DownloadFile' $message
+                throw $message
             }
         }
     }
@@ -323,13 +320,13 @@ begin {
 process {
     if (([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
             [Security.Principal.WindowsBuiltInRole]::Administrator) -eq $false) {
-        $Message = 'Unable to proceed without administrative privileges'
-        Write-FalconLog 'CheckAdmin' $Message
-        throw $Message
+        $message = 'Unable to proceed without administrative privileges'
+        Write-FalconLog 'CheckAdmin' $message
+        throw $message
     }
     elseif (Get-Service | Where-Object { $_.Name -eq 'CSFalconService' }) {
-        $Message = "'CSFalconService' running. Falcon sensor is already installed."
-        Write-FalconLog 'CheckService' $Message
+        $message = "'CSFalconService' running. Falcon sensor is already installed."
+        Write-FalconLog 'CheckService' $message
         exit 0
     }
     else {
@@ -339,15 +336,15 @@ process {
                 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
             }
             catch {
-                $Message = $_
-                Write-FalconLog 'TlsCheck' $Message
-                throw $Message
+                $message = $_
+                Write-FalconLog 'TlsCheck' $message
+                throw $message
             }
         }
         if (!($PSVersionTable.CLRVersion.ToString() -ge 3.5)) {
-            $Message = '.NET Framework 3.5 or newer is required'
-            Write-FalconLog 'NetCheck' $Message
-            throw $Message
+            $message = '.NET Framework 3.5 or newer is required'
+            Write-FalconLog 'NetCheck' $message
+            throw $message
         }
     }
 
@@ -368,13 +365,14 @@ process {
         $Headers['Content-Type'] = 'application/json'
     }
     else {
-        $Message = 'Unable to proceed without valid API credentials. Ensure you pass the required parameters or define them in the script.'
-        Write-FalconLog 'CheckCredentials' $Message
-        throw $Message
+        $message = 'Unable to proceed without valid API credentials. Ensure you pass the required parameters or define them in the script.'
+        Write-FalconLog 'CheckCredentials' $message
+        throw $message
     }
 
     # Get CCID from API if not provided
     if (!$FalconCid) {
+        Write-FalconLog 'GetCcid' 'No CCID provided. Attempting to retrieve from the CrowdStrike Falcon API.'
         $url = "${BaseUrl}/sensors/queries/installers/ccid/v1"
         $ccid_scope = @{
             'Sensor Download' = @('Read')
@@ -383,15 +381,18 @@ process {
 
         $message = "Retrieved CCID: $ccid"
         Write-FalconLog 'GetCcid' $message
-        Write-Host $message
         $InstallParams += " CID=$ccid"
     }
     else {
+        $message = "Using provided CCID: $FalconCid"
+        Write-FalconLog 'GetCcid' $message
         $InstallParams += " CID=$FalconCid"
     }
 
     # Get sensor version from policy
-    $filter = "platform_name:'Windows'+name:'$($SensorUpdatePolicyName.ToLower())'"
+    $message = "Retrieving sensor policy details for '$($SensorUpdatePolicyName)'"
+    Write-FalconLog 'GetPolicy' $message
+    $filter = "platform_name:'Windows'+name.raw:'$($SensorUpdatePolicyName.ToLower())'"
     $url = "${BaseUrl}/policy/combined/sensor-update/v2?filter=$([System.Web.HttpUtility]::UrlEncode($filter)))"
     $policy_scope = @{
         'Sensor update policies' = @('Read')
@@ -400,11 +401,20 @@ process {
     $policyId = $policyDetails.id
     $build = $policyDetails[0].settings.build
     $version = $policyDetails[0].settings.sensor_version
-    $message = "Retrieved policy details: Policy ID: $policyId, Build: $build, Version: $version"
-    Write-FalconLog 'GetPolicy' $Message
-    Write-Host $Message
+
+    # Make sure we got a version from the policy
+    if (!$version) {
+        $message = "Unable to retrieve sensor version from policy '$($SensorUpdatePolicyName)'. Please check the policy and try again."
+        Write-FalconLog 'GetPolicy' $message
+        throw $message
+    }
+
+    $message = "Retrieved sensor policy details: Policy ID: $policyId, Build: $build, Version: $version"
+    Write-FalconLog 'GetPolicy' $message
 
     # Get installer details based on policy version
+    $message = "Retrieving installer details for sensor version: '$($version)'"
+    Write-FalconLog 'GetInstaller' $message
     $encodedFilter = [System.Web.HttpUtility]::UrlEncode("platform:'windows'+version:'$($version)'")
     $url = "${BaseUrl}/sensors/combined/installers/v1?filter=${encodedFilter}"
     $installer_scope = @{
@@ -415,38 +425,37 @@ process {
     if ( $installerDetails.sha256 -and $installerDetails.name ) {
         $cloudHash = $installerDetails.sha256
         $cloudFile = $installerDetails.name
-        $message = "Matched installer '$cloudHash' ($cloudFile)"
-        Write-FalconLog 'GetInstaller' $Message
-        Write-Host $Message
+        $message = "Found installer '$cloudHash' ($cloudFile)"
+        Write-FalconLog 'GetInstaller' $message
     }
     else {
         $message = "Failed to retrieve installer details."
-        Write-FalconLog 'GetInstaller' $Message
-        throw $Message
+        Write-FalconLog 'GetInstaller' $message
+        throw $message
     }
 
     # Download the installer
     $localFile = Join-Path -Path $WinTemp -ChildPath $cloudFile
+    Write-FalconLog 'DownloadFile' "Downloading installer to: '$localFile'"
     $url = "${BaseUrl}/sensors/entities/download-installer/v1?id=$cloudHash"
     Invoke-FalconDownload -url $url -Outfile $localFile
 
     if (Test-Path $localFile) {
         $localHash = Get-InstallerHash -Path $localFile
-        $message = "Downloaded '$localFile' ($localHash)"
-        Write-FalconLog 'DownloadFile' $Message
-        Write-Host $Message
+        $message = "Successfull downloaded installer '$localFile' ($localHash)"
+        Write-FalconLog 'DownloadFile' $message
     }
     else {
         $message = "Failed to download installer."
-        Write-FalconLog 'DownloadFile' $Message
-        throw $Message
+        Write-FalconLog 'DownloadFile' $message
+        throw $message
     }
 
     # Compare the hashes prior to installation
     if ($cloudHash -ne $localHash) {
         $message = "Hash mismatch on download (Local: $localHash, Cloud: $cloudHash)"
-        Write-FalconLog 'CheckHash' $Message
-        throw $Message
+        Write-FalconLog 'CheckHash' $message
+        throw $message
     }
 
     # Additional parameters
@@ -461,28 +470,29 @@ process {
     $InstallParams += " ProvWaitTime=$ProvWaitTime"
 
     # Begin installation
+    Write-FalconLog 'StartProcess' "Starting installer with parameters '$InstallParams'"
     $process = (Start-Process -FilePath $LocalFile -ArgumentList $InstallParams -PassThru -ErrorAction SilentlyContinue)
     Write-FalconLog 'StartProcess' "Started '$LocalFile' ($($process.Id))"
-    Write-FalconLog $null "Waiting for the installer process to complete with PID ($($process.Id))"
+    Write-FalconLog 'StartProcess' "Waiting for the installer process to complete with PID ($($process.Id))"
     Wait-Process -Id $process.Id
-    Write-FalconLog $null "Installer process with PID ($($process.Id)) has completed"
+    Write-FalconLog 'StartProcess' "Installer process with PID ($($process.Id)) has completed"
 
     if ($process.ExitCode -eq 1244) {
-        $Message = "Exit code 1244: Falcon was unable to communicate with the CrowdStrike cloud. Please check your installation token and try again."
-        Write-FalconLog 'InstallerProcess' $Message
-        throw $Message
+        $message = "Exit code 1244: Falcon was unable to communicate with the CrowdStrike cloud. Please check your installation token and try again."
+        Write-FalconLog 'InstallerProcess' $message
+        throw $message
     }
     elseif ($process.ExitCode -ne 0) {
         $errOut = $process.StandardError.ReadToEnd()
-        $Message = "Falcon installer exited with code $($process.ExitCode). Error: $errOut"
-        Write-FalconLog 'InstallerProcess' $Message
-        throw $Message
+        $message = "Falcon installer exited with code $($process.ExitCode). Error: $errOut"
+        Write-FalconLog 'InstallerProcess' $message
+        throw $message
     }
     else {
-        $Message = "Falcon installer exited with code $($process.ExitCode)"
+        $message = "Falcon installer exited with code $($process.ExitCode)"
     }
 
-    Write-FalconLog $null $Message
+    Write-FalconLog 'StartProcess' $message
 
 
     @('DeleteInstaller', 'DeleteScript') | ForEach-Object {

--- a/powershell/install/falcon_windows_install.ps1
+++ b/powershell/install/falcon_windows_install.ps1
@@ -14,7 +14,7 @@ The script must be run as an administrator on the local machine in order for the
 to complete, and the OAuth2 API Client being used requires 'sensor-update-policies:read' and
 'sensor-download:read' permissions.
 .PARAMETER FalconCloud
-CrowdStrike Falcon OAuth2 API Hostname ['https://api.crowdstrike.com' if left undefined]
+CrowdStrike Falcon OAuth2 API Hostname [default: autodiscover]
 .PARAMETER FalconClientId
 CrowdStrike Falcon OAuth2 API Client Id [Required]
 .PARAMETER FalconClientSecret
@@ -33,8 +33,6 @@ Script log location ['Windows\Temp\InstallFalcon.log' if left undefined]
 Delete sensor installer package when complete [default: $true]
 .PARAMETER DeleteScript
 Delete script when complete [default: $false]
-.PARAMETER Uninstall
-Uninstall the sensor from the host [default: $false]
 .PARAMETER ProvToken
 Provisioning token to use for sensor installation [default: $null]
 .PARAMETER ProvWaitTime
@@ -60,9 +58,8 @@ Updated 2021-10-22 to include 'sensor_version' property when matching policy to 
 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'DeleteInstaller')]
 param(
     [Parameter(Position = 1)]
-    [ValidateSet('https://api.crowdstrike.com', 'https://api.us-2.crowdstrike.com',
-        'https://api.eu-1.crowdstrike.com', 'https://api.laggar.gcw.crowdstrike.com')]
-    [string] $FalconCloud = 'https://api.crowdstrike.com',
+    [ValidateSet('autodiscover', 'us-1', 'us-2', 'eu-1', 'us-gov-1')]
+    [string] $FalconCloud = 'autodiscover',
 
     [Parameter(Position = 2)]
     [string] $FalconClientId,
@@ -89,18 +86,15 @@ param(
     [bool] $DeleteScript = $false,
 
     [Parameter(Position = 10)]
-    [bool] $Uninstall = $false,
-
-    [Parameter(Position = 11)]
     [string] $ProvToken,
 
-    [Parameter(Position = 12)]
+    [Parameter(Position = 11)]
     [int] $ProvWaitTime = 1200,
 
-    [Parameter(Position = 13)]
+    [Parameter(Position = 12)]
     [string] $Tags,
 
-    [Parameter(Position = 14)]
+    [Parameter(Position = 13)]
     [ValidatePattern('\w{32}-\w{2}')]
     [string] $FalconCid
 )
@@ -115,92 +109,7 @@ begin {
     else {
         $PSScriptRoot
     }
-    $WinSystem = [Environment]::GetFolderPath('System')
-    $WinTemp = $WinSystem -replace 'system32', 'Temp'
-    if (!$LogPath) {
-        $LogPath = Join-Path -Path $WinTemp -ChildPath 'InstallFalcon.log'
-    }
 
-    if ($Uninstall) {
-        $UninstallerName = 'WindowsSensor*.exe'
-        $UninstallerCachePath = "C:\ProgramData\Package Cache"
-        $UninstallerPath = Get-ChildItem -Include $UninstallerName -Path $UninstallerCachePath -Recurse | ForEach-Object { $_.FullName }
-    }
-
-    $Falcon = New-Object System.Net.WebClient
-    $Falcon.Encoding = [System.Text.Encoding]::UTF8
-    $Falcon.BaseAddress = $FalconCloud
-
-    $Patterns = @{
-        access_token = '"(?<name>access_token)": "(?<access_token>.*)",'
-        build        = '"(?<name>build)": "(?<version>.+)",'
-        ccid         = '(?<ccid>\w{32}-\w{2})'
-        csregion     = '(?<name>X-Cs-Region): ([a-z0-9\-]+)'
-        major_minor  = '"(?<name>sensor_version)": "(?<version>\d{1,}\.\d{1,})\.\d+",'
-        policy_id    = '"(?<name>id)": "(?<id>\w{32})",'
-        version      = '"(?<name>sensor_version)": "(?<version>.+)",'
-    }
-
-
-    function Invoke-FalconCloud ([string] $xCsRegion) {
-        $Output = switch ($xCsRegion) {
-            'us-1' { 'https://api.crowdstrike.com'; Break }
-            'us-2' { 'https://api.us-2.crowdstrike.com'; Break }
-            'eu-1' { 'https://api.eu-1.crowdstrike.com'; Break }
-            'us-gov-1' { 'https://api.laggar.gcw.crowdstrike.com'; Break }
-        }
-        return $Output
-    }
-    function Get-InstallerHash ([string] $Path) {
-        $Output = if (Test-Path $Path) {
-            $Algorithm = [System.Security.Cryptography.HashAlgorithm]::Create("SHA256")
-            $Hash = [System.BitConverter]::ToString(
-                $Algorithm.ComputeHash([System.IO.File]::ReadAllBytes($Path)))
-            if ($Hash) {
-                $Hash.Replace('-', '')
-            }
-            else {
-                $null
-            }
-        }
-        return $Output
-    }
-    function Invoke-FalconAuth ([hashtable] $Body) {
-        $Headers = @{'Accept' = 'application/json'; 'Content-Type' = 'application/x-www-form-urlencoded'; 'charset' = 'utf-8' }
-        $Response = Invoke-WebRequest -Uri "$FalconCloud/oauth2/token" -UseBasicParsing -Method 'POST' -Headers $Headers -Body $Body -MaximumRedirection 0
-
-        if ($Response.RawContent -match $Patterns.csregion) {
-            $region = [regex]::Matches($Response.RawContent, $Patterns.csregion)[0].Groups['1'].Value
-            $Falcon.BaseAddress = Invoke-FalconCloud $region
-        }
-
-        if ($Response.StatusCode -match 308) {
-            $AutoDiscoveredCloud = Invoke-FalconCloud $region
-            $Response = Invoke-WebRequest -Uri "$AutoDiscoveredCloud/oauth2/token" -UseBasicParsing -Method 'POST' -Headers $Headers -Body $Body
-        }
-
-        if ($Response.Content -match $Patterns.access_token) {
-            $AccessToken = [regex]::Matches($Response.Content, $Patterns.access_token)[0].Groups['access_token'].Value
-            $Falcon.Headers.Add('Authorization', "bearer $AccessToken")
-        }
-        $Falcon.Headers.Remove('Content-Type')
-    }
-    function Invoke-FalconDownload ([string] $Path, [string] $Outfile) {
-        $Falcon.Headers.Add('Accept', 'application/octet-stream')
-        $Falcon.DownloadFile($Path, $Outfile)
-    }
-    function Invoke-FalconGet ([string] $Path) {
-        $Falcon.Headers.Add('Accept', 'application/json')
-        $Request = $Falcon.OpenRead($Path)
-        $Stream = New-Object System.IO.StreamReader $Request
-        $Output = $Stream.ReadToEnd()
-        @($Request, $Stream) | ForEach-Object {
-            if ($null -ne $_) {
-                $_.Dispose()
-            }
-        }
-        return $Output
-    }
     function Write-FalconLog ([string] $Source, [string] $Message) {
         $Content = @(Get-Date -Format 'yyyy-MM-dd hh:MM:ss')
         if ($Source -notmatch '^(StartProcess|Delete(Installer|Script))$' -and
@@ -219,6 +128,191 @@ begin {
             }
         }
     }
+
+    function Get-FalconCloud ([string] $xCsRegion) {
+        $Output = switch ($xCsRegion) {
+            'autodiscover' { 'https://api.crowdstrike.com'; break }
+            'us-1' { 'https://api.crowdstrike.com'; break }
+            'us-2' { 'https://api.us-2.crowdstrike.com'; break }
+            'eu-1' { 'https://api.eu-1.crowdstrike.com'; break }
+            'us-gov-1' { 'https://api.laggar.gcw.crowdstrike.com'; break }
+            default { throw "Provided region $xCsRegion is invalid. Please set FalconCloud to a valid region or 'autodiscover'"; break }
+        }
+        return $Output
+    }
+
+    function Invoke-FalconAuth([string] $BaseUrl, [hashtable] $Body, [string] $FalconCloud) {
+        $Headers = @{'Accept' = 'application/json'; 'Content-Type' = 'application/x-www-form-urlencoded'; 'charset' = 'utf-8' }
+        try {
+            $response = Invoke-WebRequest -Uri "$($BaseUrl)/oauth2/token" -UseBasicParsing -Method 'POST' -Headers $Headers -Body $Body
+            $content = ConvertFrom-Json -InputObject $response.Content
+
+            if ([string]::IsNullOrEmpty($content.access_token)) {
+                $Message = 'Unable to authenticate to the CrowdStrike Falcon API. Please check your credentials and try again.'
+                throw $Message
+            }
+
+            $Headers.Add('Authorization', "bearer $($content.access_token)")
+        }
+        catch {
+            # Handle redirects
+            $response = $_.Exception.Response
+
+            if (!$response) {
+                $Message = "Unhandled error occurred while authenticating to the CrowdStrike Falcon API. Error: $($_.Exception.Message)"
+                Write-FalconLog -Source 'Invoke-FalconAuth' -Message $Message
+                throw $Message
+            }
+
+            if ($response.StatusCode -in @(301, 302, 303, 307, 308)) {
+                # If autodiscover is enabled, try to get the correct cloud
+                if ($FalconCloud -eq 'autodiscover') {
+                    if ($response.Headers.Contains('X-Cs-Region')) {
+                        $region = $response.Headers.GetValues('X-Cs-Region')[0]
+                    }
+                    else {
+                        $Message = 'Received a redirect but no X-Cs-Region header was provided. Unable to autodiscover the FalconCloud. Please set FalconCloud to the correct region.'
+                        Write-FalconLog -Source 'Invoke-FalconAuth' -Message $Message
+                        throw $Message
+                    }
+
+                    $BaseUrl = Get-FalconCloud($region)
+                    $BaseUrl, $Headers = Invoke-FalconAuth -BaseUrl $BaseUrl -Body $Body -FalconCloud $FalconCloud
+
+                }
+                else {
+                    $Message = "Received a redirect. Please set FalconCloud to 'autodiscover' or the correct region."
+                    Write-FalconLog -Source 'Invoke-FalconAuth' -Message $Message
+                    throw $Message
+                }
+            }
+            else {
+                $Message = "Received a $($response.StatusCode) response from $($BaseUrl)oauth2/token. Please check your credentials and try again. Error: $($response.StatusDescription)"
+                Write-FalconLog -Source 'Invoke-FalconAuth' -Message $Message
+                throw $Message
+            }
+        }
+
+        return $BaseUrl, $Headers
+    }
+
+    function Test-FalconCredential([string] $FalconClientId , [string] $FalconClientSecret ) {
+        if ($FalconClientId -and $FalconClientSecret) {
+            return $true
+        }
+        else {
+            return $false
+        }
+    }
+
+    $WinSystem = [Environment]::GetFolderPath('System')
+    $WinTemp = $WinSystem -replace 'system32', 'Temp'
+    if (!$LogPath) {
+        $LogPath = Join-Path -Path $WinTemp -ChildPath 'InstallFalcon.log'
+    }
+
+    function Format-403Error([string] $url, [hashtable] $scope) {
+        $Message = "Insufficient permission error when calling $($url). Verify the following scopes are included in the API key:"
+        foreach ($key in $scope.Keys) {
+            $Message += "`r`n`t '$($key)' with: $($scope[$key])"
+        }
+        return $Message
+    }
+
+    function Format-FalconResponseError($errors) {
+        $Message = ''
+        foreach ($error in $errors) {
+            $Message += "`r`n`t $($error.message)"
+        }
+        return $Message
+    }
+
+    function Get-ResourceContent([string] $url, [string] $logKey, [hashtable] $scope, [string] $errorMessage) {
+        try {
+            $response = Invoke-WebRequest -Uri $url -UseBasicParsing -Method 'GET' -Headers $Headers -MaximumRedirection 0
+            $content = ConvertFrom-Json -InputObject $response.Content
+
+            if ($content.errors) {
+                $message = "Error when getting content: "
+                $message += Format-FalconResponseError -errors $content.errors
+                Write-FalconLog $logKey $message
+                throw $Message
+            }
+
+            if ($content.resources) {
+                return $content.resources
+            }
+            else {
+                $message = $errorMessage
+                throw $message
+            }
+        }
+        catch {
+            $response = $_.Exception.Response
+
+            Write-FalconLog $_.Exception
+
+            if (!$response) {
+                $message = "Unhandled error occurred. Error: $($_.Exception.Message)"
+                throw $message
+            }
+
+            if ($response.StatusCode -eq 403) {
+                $message = Format-403Error -url $url -scope $scope
+                Write-FalconLog $logKey $message
+                throw $message
+            }
+            else {
+                $message = "Received a $($response.StatusCode) response from ${url}. Error: $($response.StatusDescription)"
+                Write-FalconLog $logKey $message
+                Write-Host $message
+                throw $message
+            }
+        }
+    }
+
+    function Get-InstallerHash ([string] $Path) {
+        $Output = if (Test-Path $Path) {
+            $Algorithm = [System.Security.Cryptography.HashAlgorithm]::Create("SHA256")
+            $Hash = [System.BitConverter]::ToString(
+                $Algorithm.ComputeHash([System.IO.File]::ReadAllBytes($Path)))
+            if ($Hash) {
+                $Hash.Replace('-', '')
+            }
+            else {
+                $null
+            }
+        }
+        return $Output
+    }
+
+    function Invoke-FalconDownload ([string] $url, [string] $Outfile) {
+        try {
+            $response = Invoke-WebRequest -Uri $url -UseBasicParsing -Method 'GET' -Headers $Headers -OutFile $Outfile
+        }
+        catch {
+            $response = $_.Exception.Response
+            if (!$response) {
+                $Message = "Unhandled error occurred. Error: $($_.Exception.Message)"
+                Write-FalconLog 'DownloadFile' $Message
+                throw $Message
+            }
+            if ($response.StatusCode -eq 403) {
+                $scope = @{
+                    'Sensor Download' = @('Read')
+                }
+                $message = Format-403Error -url $url -scope $scope
+                Write-FalconLog 'Permissions' $message
+                throw $message
+            }
+            else {
+                $Message = "Received a $($response.StatusCode) response from ${url}. Error: $($response.StatusDescription)"
+                Write-FalconLog 'DownloadFile' $Message
+                throw $Message
+            }
+        }
+    }
+
     if (!$SensorUpdatePolicyName) {
         $SensorUpdatePolicyName = 'platform_default'
     }
@@ -233,83 +327,13 @@ process {
         Write-FalconLog 'CheckAdmin' $Message
         throw $Message
     }
-    elseif ($Uninstall) {
-        $AgentService = Get-Service -Name CSAgent -ErrorAction SilentlyContinue
-        if (!$AgentService) {
-            $Message = "'CSFalconService' is not installed"
-            Write-FalconLog 'CheckService' $Message
-            throw $Message
-        }
-
-        if (-not (Test-Path -Path $UninstallerPath)) {
-            $Message = "${UninstallerName} not found."
-            Write-FalconLog 'CheckUninstaller' $Message
-            throw $Message
-        }
-
-        $Message = 'Uninstalling Falcon Sensor...'
-        Write-FalconLog 'Uninstaller' $Message
-
-        $UninstallParams = '/uninstall /quiet'
-        $UninstallerProcess = Start-Process -FilePath "$UninstallerPath" -ArgumentList $UninstallParams -PassThru -Wait
-        $UninstallerProcessId = $UninstallerProcess.Id
-        Write-FalconLog 'StartProcess' "Started '$UninstallerPath' ($UninstallerProcessId)"
-        if ($UninstallerProcess.ExitCode -ne 0) {
-            $Message = "Uninstaller returned exit code $($UninstallerProcess.ExitCode)"
-            Write-FalconLog "UninstallError" $Message
-            throw $Message
-        }
-
-        $AgentService = Get-Service -Name CSAgent -ErrorAction SilentlyContinue
-        if ($AgentService -and $AgentService.Status -eq 'Running') {
-            $Message = 'Service uninstall failed...'
-            Write-FalconLog "ServiceError" $Message
-            throw $Message
-        }
-
-        if (Test-Path -Path HKLM:\System\Crowdstrike) {
-            $Message = 'Registry key removal failed...'
-            Write-FalconLog "RegistryError" $Message
-            throw $Message
-        }
-
-        if (Test-Path -Path"${env:SYSTEMROOT}\System32\drivers\CrowdStrike") {
-            $Message = 'Driver removal failed...'
-            Write-FalconLog "DriverError" $Message
-            throw $Message
-        }
-
-        if ($DeleteScript) {
-            $FilePath = Join-Path -Path $ScriptPath -ChildPath $ScriptName
-            if (Test-Path $FilePath) {
-                Remove-Item -Path $FilePath -Force
-            }
-            if (Test-Path $FilePath) {
-                Write-FalconLog $_ "Failed to delete '$FilePath'"
-            }
-            else {
-                Write-FalconLog $_ "Deleted '$FilePath'"
-            }
-        }
-
-        $Message = 'Successfully finished uninstall...'
-        Write-FalconLog 'Uninstaller' $Message
-        Exit 0
-    }
     elseif (Get-Service | Where-Object { $_.Name -eq 'CSFalconService' }) {
         $Message = "'CSFalconService' running. Falcon sensor is already installed."
         Write-FalconLog 'CheckService' $Message
         exit 0
     }
     else {
-        if (!$FalconClientId) {
-            Get-Help $MyInvocation.InvocationName | Out-String
-            throw "Missing parameter 'FalconClientId'"
-        }
-        if (!$FalconClientSecret) {
-            Get-Help $MyInvocation.InvocationName | Out-String
-            throw "Missing parameter 'FalconClientSecret'"
-        }
+        $credsProvided = Test-FalconCredential $FalconClientId $FalconClientSecret
         if ([Net.ServicePointManager]::SecurityProtocol -notmatch 'Tls12') {
             try {
                 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
@@ -327,122 +351,105 @@ process {
         }
     }
 
-    $ApiClient = @{}
-    $ApiClient["client_id"] = $FalconClientId
-    $ApiClient["client_secret"] = $FalconClientSecret
+    # Configure OAuth2 authentication
+    if ($credsProvided) {
+        $Headers = @{'Accept' = 'application/json'; 'Content-Type' = 'application/x-www-form-urlencoded'; 'charset' = 'utf-8' }
+        $BaseUrl = Get-FalconCloud $FalconCloud
 
-    if ($MemberCid) {
-        $ApiClient["member_cid"] = $MemberCid
-    }
+        $Body = @{}
+        $Body['client_id'] = $FalconClientId
+        $Body['client_secret'] = $FalconClientSecret
 
-    Invoke-FalconAuth $ApiClient
-    if ($Falcon.Headers.Keys -contains 'Authorization') {
-        Write-FalconLog 'GetAuth' "FalconClientId: $($FalconClientId), FalconCloud: $($Falcon.BaseAddress)"
+        if ($MemberCid) {
+            $Body['member_cid'] = $MemberCid
+        }
+
+        $BaseUrl, $Headers = Invoke-FalconAuth -BaseUrl $BaseUrl -Body $Body -FalconCloud $FalconCloud
+        $Headers['Content-Type'] = 'application/json'
     }
     else {
-        $Message = 'Failed to retrieve authorization token'
-        Write-FalconLog 'GetAuth' $Message
+        $Message = 'Unable to proceed without valid API credentials. Ensure you pass the required parameters or define them in the script.'
+        Write-FalconLog 'CheckCredentials' $Message
         throw $Message
     }
 
-    # If FalconCid is not provided, get it from the API
+    # Get CCID from API if not provided
     if (!$FalconCid) {
-        $Response = Invoke-FalconGet '/sensors/queries/installers/ccid/v1'
-        if ($Response -match $Patterns.ccid) {
-            $Ccid = [regex]::Matches($Response, $Patterns.ccid)[0].Groups['ccid'].Value
-            $Message = "Retrieved CCID: $Ccid"
-            Write-FalconLog 'GetCcid' $Message
-            $InstallParams += " CID=$Ccid"
+        $url = "${BaseUrl}/sensors/queries/installers/ccid/v1"
+        $ccid_scope = @{
+            'Sensor Download' = @('Read')
         }
-        else {
-            $Message = 'Failed to retrieve CCID'
-            Write-FalconLog 'GetCcid' $Message
-            throw $Message
-        }
-    } else {
-        $Message = "Using provided CCID: $FalconCid"
-        Write-FalconLog 'GetCcid' $Message
+        $ccid = Get-ResourceContent -url $url -logKey 'GetCcid' -scope $ccid_scope -errorMessage "Unable to grab CCID from the CrowdStrike Falcon API."
+
+        $message = "Retrieved CCID: $ccid"
+        Write-FalconLog 'GetCcid' $message
+        Write-Host $message
+        $InstallParams += " CID=$ccid"
+    }
+    else {
         $InstallParams += " CID=$FalconCid"
     }
 
-    $Response = Invoke-FalconGet ("/policy/combined/sensor-update/v2?filter=platform_name:" +
-        "'Windows'%2Bname:'$($SensorUpdatePolicyName.ToLower())'")
-    $PolicyId = if ($Response -match $Patterns.policy_id) {
-        [regex]::Matches($Response, $Patterns.policy_id)[0].Groups['id'].Value
+    # Get sensor version from policy
+    $filter = "platform_name:'Windows'+name:'$($SensorUpdatePolicyName.ToLower())'"
+    $url = "${BaseUrl}/policy/combined/sensor-update/v2?filter=$([System.Web.HttpUtility]::UrlEncode($filter)))"
+    $policy_scope = @{
+        'Sensor update policies' = @('Read')
     }
+    $policyDetails = Get-ResourceContent -url $url -logKey 'GetPolicy' -scope $policy_scope -errorMessage "Unable to fetch policy details from the CrowdStrike Falcon API."
+    $policyId = $policyDetails.id
+    $build = $policyDetails[0].settings.build
+    $version = $policyDetails[0].settings.sensor_version
+    $message = "Retrieved policy details: Policy ID: $policyId, Build: $build, Version: $version"
+    Write-FalconLog 'GetPolicy' $Message
+    Write-Host $Message
 
-    if ($Response -match $Patterns.build -or $Response -match $Patterns.version) {
-        $Build = [regex]::Matches($Response, $Patterns.build)[0].Groups['version'].Value
-        $Version = [regex]::Matches($Response, $Patterns.version)[0].Groups['version'].Value
-        $MajorMinor = if ($Version) {
-            [regex]::Matches($Response, $Patterns.major_minor)[0].Groups['version'].Value
-        }
-        $Patch = if ($Build) {
-            ($Build).Split('|')[0]
-        }
-        elseif ($Version) {
-            ($Version).Split('.')[-1]
-        }
-        if ($Patch) {
-            Write-FalconLog 'GetVersion' "Policy '$PolicyId' has build '$Patch' assigned"
-        }
-        else {
-            $Message = "Failed to determine sensor version for policy '$PolicyId'"
-            Write-FalconLog 'GetVersion' $Message
-            throw $Message
-        }
+    # Get installer details based on policy version
+    $encodedFilter = [System.Web.HttpUtility]::UrlEncode("platform:'windows'+version:'$($version)'")
+    $url = "${BaseUrl}/sensors/combined/installers/v1?filter=${encodedFilter}"
+    $installer_scope = @{
+        'Sensor Download' = @('Read')
+    }
+    $installerDetails = Get-ResourceContent -url $url -logKey 'GetInstaller' -scope $installer_scope -errorMessage "Unable to fetch installer details from the CrowdStrike Falcon API."
+
+    if ( $installerDetails.sha256 -and $installerDetails.name ) {
+        $cloudHash = $installerDetails.sha256
+        $cloudFile = $installerDetails.name
+        $message = "Matched installer '$cloudHash' ($cloudFile)"
+        Write-FalconLog 'GetInstaller' $Message
+        Write-Host $Message
     }
     else {
-        $Message = "Failed to match policy name '$($SensorUpdatePolicyName.ToLower())'"
-        Write-FalconLog 'GetPolicy' $Message
-        throw $Message
-    }
-
-    $Response = Invoke-FalconGet "/sensors/combined/installers/v1?filter=platform:'windows'"
-    if ($Response) {
-        $BuildMatch = '\d{1,}?\.\d{1,}\.' + $Patch
-        if ($MajorMinor) {
-            $BuildMatch = "($BuildMatch|$([regex]::Escape($MajorMinor))\.\d+)"
-        }
-        $Installer = '"name": "(?<filename>(\w+\.){1,}?exe)",\n\s+"description": "(.*)?Falcon(.*)",(\n.*){1,}"sh' +
-        'a256": "(?<hash>\w{64})",(\n.*){1,}"version": "' + $BuildMatch + '"'
-        $Match = $Response.Split('}') | Where-Object { $_ -match $Installer }
-        if ($Match) {
-            $CloudHash = [regex]::Matches($Match, $Installer)[0].Groups['hash'].Value
-            $CloudFile = [regex]::Matches($Match, $Installer)[0].Groups['filename'].Value
-            Write-FalconLog 'GetInstaller' "Matched installer '$CloudHash' ($CloudFile)"
-        }
-        else {
-            $MatchValue = "'$Patch'"
-            if ($MajorMinor) {
-                $MatchValue += " or '$MajorMinor'"
-            }
-            $Message = "Unable to match installer using $MatchValue"
-            Write-FalconLog 'GetInstaller' $Message
-            throw $Message
-        }
-    }
-    else {
-        $Message = 'Failed to retrieve available installer list'
+        $message = "Failed to retrieve installer details."
         Write-FalconLog 'GetInstaller' $Message
         throw $Message
     }
 
-    if ($CloudHash -and $CloudFile) {
-        $LocalFile = Join-Path -Path $WinTemp -ChildPath $CloudFile
-        Invoke-FalconDownload "/sensors/entities/download-installer/v1?id=$CloudHash" $LocalFile
-        if (Test-Path $LocalFile) {
-            Write-FalconLog 'DownloadFile' "Created '$LocalFile'"
-            $LocalHash = Get-InstallerHash $LocalFile
-        }
+    # Download the installer
+    $localFile = Join-Path -Path $WinTemp -ChildPath $cloudFile
+    $url = "${BaseUrl}/sensors/entities/download-installer/v1?id=$cloudHash"
+    Invoke-FalconDownload -url $url -Outfile $localFile
+
+    if (Test-Path $localFile) {
+        $localHash = Get-InstallerHash -Path $localFile
+        $message = "Downloaded '$localFile' ($localHash)"
+        Write-FalconLog 'DownloadFile' $Message
+        Write-Host $Message
+    }
+    else {
+        $message = "Failed to download installer."
+        Write-FalconLog 'DownloadFile' $Message
+        throw $Message
     }
 
-    if ($CloudHash -ne $LocalHash) {
-        $Message = "Hash mismatch on download (Local: $LocalHash, Cloud: $CloudHash)"
+    # Compare the hashes prior to installation
+    if ($cloudHash -ne $localHash) {
+        $message = "Hash mismatch on download (Local: $localHash, Cloud: $cloudHash)"
         Write-FalconLog 'CheckHash' $Message
         throw $Message
     }
 
+    # Additional parameters
     if ($ProvToken) {
         $InstallParams += " ProvToken=$ProvToken"
     }
@@ -453,6 +460,7 @@ process {
 
     $InstallParams += " ProvWaitTime=$ProvWaitTime"
 
+    # Begin installation
     $process = (Start-Process -FilePath $LocalFile -ArgumentList $InstallParams -PassThru -ErrorAction SilentlyContinue)
     Write-FalconLog 'StartProcess' "Started '$LocalFile' ($($process.Id))"
     Write-FalconLog $null "Waiting for the installer process to complete with PID ($($process.Id))"

--- a/powershell/install/falcon_windows_install.ps1
+++ b/powershell/install/falcon_windows_install.ps1
@@ -56,6 +56,7 @@ Updated 2021-10-22 to include 'sensor_version' property when matching policy to 
 
 [CmdletBinding()]
 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'DeleteInstaller')]
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'DeleteScript')]
 param(
     [Parameter(Position = 1)]
     [ValidateSet('autodiscover', 'us-1', 'us-2', 'eu-1', 'us-gov-1')]


### PR DESCRIPTION
closes #167 

This PR introduces a new enhanced version of the PowerShell installation script. Numerous changes were implemented to bring it more inline with the uninstall and migrate script. Big changes:

- Instead of using the System.net.webclient to handle API calls, we are now using Invoke-WebRequest to provide us with error handling and better control of the data.
- FalconCloud is the same as the other scripts. We now default to autodiscover, and use short names rather than the full url as it was before.
- Introduction to the Error Handling/Formatting functions from the other scripts
- Better logging
- Fixed flow of getting sensor version

