### PR TITLE
Linux install script fix for when multiple tags applied

### DIFF
--- a/bash/install/falcon-linux-install.sh
+++ b/bash/install/falcon-linux-install.sh
@@ -90,7 +90,8 @@ cs_sensor_register() {
         cs_falcon_args="$cs_falcon_args $cs_falconctl_opt_trace"
     fi
     # run the configuration command
-    /opt/CrowdStrike/falconctl -s -f "${cs_falcon_args}"
+    # shellcheck disable=SC2086
+    /opt/CrowdStrike/falconctl -s -f ${cs_falcon_args}
 }
 
 cs_sensor_is_running() {


### PR DESCRIPTION
Remove quotes on `cs_falcon_args` and disable shellcheck alert as otherwise no tags apply.

With quotes around "${cs_falcon_args}"
```
+ /opt/CrowdStrike/falconctl -s -f '--cid=<CIDRemoved> --tags=test1,test2,test3/tag'`
```

When verifying:

```
/opt/CrowdStrike/falconctl -g --tags
Sensor grouping tags are not set.
```
After change: 

```
+ /opt/CrowdStrike/falconctl -s -f --cid=<CIDRemoved> --tags=test1,test2,test3/tag
```

Verifying:

```
/opt/CrowdStrike/falconctl -g --tags
tags=test1,test2,test3/tag.
```