### PR TITLE
Ansible decided to move their examples folder to another repo

### DIFF
--- a/molecule/shared/playbooks/win_create.yml
+++ b/molecule/shared/playbooks/win_create.yml
@@ -65,7 +65,7 @@
       user_data: |
         <powershell>
         # Download ConfigureRemotingForAnsible.ps1 and run it
-        Invoke-WebRequest -Uri https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile ConfigureRemotingForAnsible.ps1
+        Invoke-WebRequest -Uri https://raw.githubusercontent.com/ansible/ansible-documentation/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile ConfigureRemotingForAnsible.ps1
         .\ConfigureRemotingForAnsible.ps1
         </powershell>
       image_filters: {}


### PR DESCRIPTION
This was preventing windows CI jobs that use the PS script to setup winrm.