### PR TITLE
ci: update container_sensor_pull to use molecule

### DIFF
--- a/.github/workflows/container_sensor_pull.yml
+++ b/.github/workflows/container_sensor_pull.yml
@@ -1,16 +1,18 @@
 name: "CI: container_sensor_pull"
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 23 * * *'
 
   push:
     paths:
+      - 'molecule/container_sensor_pull/**'
       - 'bash/containers/falcon-container-sensor-pull/**'
       - '.github/workflows/container_sensor_pull.yml'
 
   pull_request_target:
     types: [ labeled ]
     paths:
+      - 'molecule/container_sensor_pull/**'
       - 'bash/containers/falcon-container-sensor-pull/**'
       - '.github/workflows/container_sensor_pull.yml'
 
@@ -24,8 +26,12 @@ jobs:
     name: ${{ matrix.sensortype.type }}
     runs-on: ubuntu-latest
     env:
+      PY_COLORS: 1
+      ANSIBLE_FORCE_COLOR: 1
       FALCON_CLIENT_ID: ${{ secrets.FALCON_CLIENT_ID }}
       FALCON_CLIENT_SECRET: ${{ secrets.FALCON_CLIENT_SECRET }}
+      AWS_REGION: "us-west-1"
+      MOLECULE_VPC_SUBNET_ID: ${{ secrets.MOLECULE_VPC_SUBNET_ID }}
     permissions:
       contents: read
       id-token: write
@@ -41,6 +47,8 @@ jobs:
             cli_arg: '--kubernetes-admission-controller'
           - type: kpagent
             cli_arg: '--kubernetes-protection-agent'
+        collection_role:
+          - container_sensor_pull
 
     steps:
       - name: Check out code
@@ -53,6 +61,58 @@ jobs:
           ref: ${{github.event.pull_request.head.sha}}
         if: github.event_name == 'pull_request_target'
 
-      - name: Run script to pull ${{ matrix.sensortype.type }} image
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE }}
+          role-session-name: github-actions-molecule-ansible
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+          cache-dependency-path: '.github/workflows/container_sensor_pull.yml'
+
+      - name: Install dependencies
         run: |
-          bash bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh ${{ matrix.sensortype.cli_arg }}
+          sudo apt install apt-transport-https ca-certificates curl software-properties-common libssl-dev
+          python -m pip install --upgrade pip
+          pip install molecule "molecule-plugins[ec2]" ansible ansible-core ansible-lint boto3 botocore
+
+      - name: Run role tests
+        id: molecule-role-test
+        uses: nick-fields/retry@v2
+        env:
+          MOLECULE_INSTANCE_NAME: ${{ matrix.sensortype.type }}-sensor-pull
+          MOLECULE_REGION: ${{ env.AWS_REGION}}
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_on: error
+          command: >-
+            molecule --version &&
+            ansible --version &&
+            molecule --debug test --destroy never -s ${{ matrix.collection_role }} -- -e "cli_arg=${{ matrix.sensortype.cli_arg }}"
+        continue-on-error: true
+
+      - name: Ensure instances are destroyed
+        uses: nick-fields/retry@v2
+        env:
+          MOLECULE_INSTANCE_NAME: ${{ matrix.sensortype.type }}-sensor-pull
+          MOLECULE_REGION: ${{ env.AWS_REGION}}
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: >-
+            molecule --version &&
+            ansible --version &&
+            molecule --debug destroy -s ${{ matrix.collection_role }}
+
+      - name: Assert molecule tests passed
+        uses: nick-fields/assert-action@v1
+        with:
+          expected: success
+          actual: ${{ steps.molecule-role-test.outcome }}

--- a/molecule/container_sensor_pull/converge.yml
+++ b/molecule/container_sensor_pull/converge.yml
@@ -1,0 +1,22 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  become: true
+  vars:
+    cli_arg: ""
+  environment:
+    FALCON_CLIENT_ID: "{{ lookup('env', 'FALCON_CLIENT_ID') }}"
+    FALCON_CLIENT_SECRET: "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}"
+    ALLOW_LEGACY_CURL: "true"
+  tasks:
+    # Execute shell command
+    - name: Pull container sensor
+      ansible.builtin.script:
+        cmd: ../../bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh {{ cli_arg }}
+      register: container_pull
+
+    # Print stdout
+    - name: Task STDOUT
+      ansible.builtin.debug:
+        msg: "{{ container_pull.stdout_lines }}"

--- a/molecule/container_sensor_pull/molecule.yml
+++ b/molecule/container_sensor_pull/molecule.yml
@@ -1,0 +1,35 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+# The Default Platform is Ubunutu 20.04 LTS | T2.Micro | us-west-2
+platforms:
+  - name: "${MOLECULE_INSTANCE_NAME:-default-container-sensor-pull}"
+    image_owner: "${MOLECULE_IMAGE_OWNER:-099720109477}"
+    image_filters:
+      - architecture: "${MOLECULE_IMAGE_ARCH:-x86_64}"
+      - name: "${MOLECULE_IMAGE_NAME:-ubuntu/images/hvm-ssd/ubuntu-focal-20.04*}"
+    instance_type: "${MOLECULE_INSTANCE_TYPE:-t2.micro}"
+    region: "${MOLECULE_REGION:-us-west-2}"
+    vpc_subnet_id: "${MOLECULE_VPC_SUBNET_ID}"
+    security_group_restrict_cidr_ip: "${MOLECULE_SECURITY_GROUP_RESTRICT_CIDR_IP:-true}"
+    boot_wait_seconds: ${MOLECULE_BOOT_WAIT_SECONDS:-60}
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      stdout_callback: yaml
+  playbooks:
+    create: ../shared/playbooks/create.yml
+    destroy: ../shared/playbooks/destroy.yml
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    - destroy

--- a/molecule/container_sensor_pull/prepare.yml
+++ b/molecule/container_sensor_pull/prepare.yml
@@ -1,0 +1,25 @@
+---
+- name: Prepare (Default)
+  hosts: all
+  become: true
+  tasks:
+    # Ubuntu specific
+    - name: Install apt dependencies
+      ansible.builtin.apt:
+        name:
+          - gpg-agent
+          - curl
+        update_cache: true
+      when: ansible_pkg_mgr == 'apt'
+
+    - name: Install dependencies
+      ansible.builtin.package:
+        name:
+          - sudo
+        state: present
+
+    - name: Install Docker w/ snap
+      ansible.builtin.command:
+        cmd: snap install docker
+        creates: /snap/bin/docker
+      when: ansible_pkg_mgr == 'apt'


### PR DESCRIPTION
Fixes issue with previous ci attempt due to not having a TTY to run the docker login command through. This also makes the CI inline with our other tests by using molecule.