### PR TITLE
Simplify and Enhance Sensor Type Selection in Falcon Container Sensor Pull Script

### DIFF
--- a/bash/containers/falcon-container-sensor-pull/README.md
+++ b/bash/containers/falcon-container-sensor-pull/README.md
@@ -69,14 +69,13 @@ Help Options:
 | `-c`, `--copy <REGISTRY/NAMESPACE>`            | `$COPY`                 | `None` (Optional)          | Registry you want to copy the sensor image to. Example: `myregistry.com/mynamespace`     |
 | `-v`, `--version <SENSOR_VERSION>`             | `$SENSOR_VERSION`       | `None` (Optional)          | Specify sensor version to retrieve from the registry                                     |
 | `-p`, `--platform <SENSOR_PLATFORM>`           | `$SENSOR_PLATFORM`      | `None` (Optional)          | Specify sensor platform to retrieve from the registry                                    |
-| `-t`, `--type <SENSORTYPE>`                    | `$SENSOR_TYPE`<sup>1</sup>           | `falcon-container` (Optional) | Specify which sensor to download [`falcon-container`, `falcon-sensor`, `falcon-kac`, `kpagent`] ([see more details below](#sensor-types)) |
+| `-t`, `--type <SENSOR_TYPE>`                    | `$SENSOR_TYPE`         | `falcon-container` (Optional) | Specify which sensor to download [`falcon-container`, `falcon-sensor`, `falcon-kac`, `kpagent`] ([see more details below](#sensor-types)) |
 | `--runtime`                                    | `$CONTAINER_TOOL`       | `docker` (Optional)        | Use a different container runtime [docker, podman, skopeo]. **Default is Docker**.       |
 | `--dump-credentials`                           | `$CREDS`                | `False` (Optional)         | Print registry credentials to stdout to copy/paste into container tools                  |
 | `--list-tags`                                  | `$LISTTAGS`             | `False` (Optional)         | List all tags available for the selected sensor                                          |
 | `--allow-legacy-curl`                          | `$ALLOW_LEGACY_CURL`    | `False` (Optional)         | Allow the script to run with an older version of cURL                                    |
 | `-h`, `--help`                                 | N/A                     | `None`                     | Display help message                                                                     |
 
-> <sup>1</sup> For backwards compatibility, $SENSORTYPE can still be used in place of $SENSOR_TYPE.
 
 ### Sensor Types
 

--- a/bash/containers/falcon-container-sensor-pull/README.md
+++ b/bash/containers/falcon-container-sensor-pull/README.md
@@ -2,9 +2,15 @@
 
 Use this bash script to pull the latest **Falcon Container** sensor, **Node Kernel Mode DaemonSet** sensor, **Kubernetes Admission Controller** or **Kubernetes Protection Agent** from the CrowdStrike container registry and push it to your local Docker registry or remote registries.
 
-> :warning: **Deprecation Warning**: Starting with version 2.0.0, the `SENSORTYPE` environment variable will be deprecated and replaced with `SENSOR_TYPE`. `SENSORTYPE` will still be supported for backwards compatibility, but will be removed in a future release. Please update your code to use `SENSOR_TYPE` to specify your sensor type.
->
-> :warning: **Breaking Changes**: The following command line options have been removed and are no longer supported: `-n`, `--node`, `--kubernetes-admission-controller`, and `--kubernetes-protection-agent`. To update your code, use the `-t, --type` option to specify your sensor type. For example, to download the Kubernetes Protection Agent, use `--type kpagent`.
+## Deprecation Warning :warning:
+
+1. **Environment Variable Deprecation** : The `SENSORTYPE` environment variable will be deprecated and replaced by `SENSOR_TYPE`. This update is intended to increase readability and maintain consistency in our environment variable naming convention.
+
+2. **Command Option Deprecation** : The command line options `-n, --node`, `--kubernetes-admission-controller`, and `--kubernetes-protection-agent` will be deprecated and replaced by a single option `-t, --type`. The new `-t, --type` option will allow you to specify the sensor type in a more straightforward and simplified manner.
+
+While these changes will be officially introduced in version 2.0.0, we will continue to support the deprecated environment variable and command options until that release. We strongly encourage you to adapt your usage to include the new `SENSOR_TYPE` environment variable and `-t, --type` command option to ensure a smooth transition when version 2.0.0 is released.
+
+Please refer to the updated usage instructions and examples in the [Usage](#usage) section of this README. Feel free to reach out with any questions or concerns.
 
 ## Security recommendations
 

--- a/bash/containers/falcon-container-sensor-pull/README.md
+++ b/bash/containers/falcon-container-sensor-pull/README.md
@@ -36,9 +36,7 @@ Optional Flags:
     -v, --version <SENSOR_VERSION>    specify sensor version to retrieve from the registry
     -p, --platform <SENSOR_PLATFORM>  specify sensor platform to retrieve e.g x86_64, aarch64
 
-    -n, --node                        download node sensor instead of container sensor
-    --kubernetes-admission-controller download kubernetes admission controller instead of falcon sensor
-    --kubernetes-protection-agent     download kubernetes protection agent instead of falcon sensor
+    -t, --type <SENSOR_TYPE>          specify which sensor to download [falcon-container|falcon-sensor|falcon-kac|kpagent]
     --runtime                         use a different container runtime [docker, podman, skopeo]. Default is docker.
     --dump-credentials                print registry credentials to stdout to copy/paste into container tools.
     --list-tags                       list all tags available for the selected sensor
@@ -61,14 +59,25 @@ Help Options:
 | `-c`, `--copy <REGISTRY/NAMESPACE>`            | `$COPY`                 | `None` (Optional)          | Registry you want to copy the sensor image to. Example: `myregistry.com/mynamespace`     |
 | `-v`, `--version <SENSOR_VERSION>`             | `$SENSOR_VERSION`       | `None` (Optional)          | Specify sensor version to retrieve from the registry                                     |
 | `-p`, `--platform <SENSOR_PLATFORM>`           | `$SENSOR_PLATFORM`      | `None` (Optional)          | Specify sensor platform to retrieve from the registry                                    |
-| `-n`, `--node`                                 | `$SENSORTYPE`           | `falcon-sensor` (Optional) | Flag to download Node Sensor. **Default is Container Sensor**.                           |
-| `--kubernetes-admission-controller`            | `$SENSORTYPE`           | `falcon-kac` (Optional)    | Flag to download Kubernetes Admission Controller. **Default is Container Sensor**.       |
-| `--kubernetes-protection-agent`                | `$SENSORTYPE`           | `kpagent` (Optional)       | Flag to download Kubernetes Protection Agent. **Default is Container Sensor**.           |
+| `-t`, `--type <SENSORTYPE>`                    | `$SENSOR_TYPE`<sup>1</sup>           | `falcon-sensor` (Optional) | Specify which sensor to download [`falcon-container`, `falcon-sensor`, `falcon-kac`, `kpagent`] ([see more details below](#sensor-types)) |
 | `--runtime`                                    | `$CONTAINER_TOOL`       | `docker` (Optional)        | Use a different container runtime [docker, podman, skopeo]. **Default is Docker**.       |
 | `--dump-credentials`                           | `$CREDS`                | `False` (Optional)         | Print registry credentials to stdout to copy/paste into container tools                  |
 | `--list-tags`                                  | `$LISTTAGS`             | `False` (Optional)         | List all tags available for the selected sensor                                          |
 | `--allow-legacy-curl`                          | `$ALLOW_LEGACY_CURL`    | `False` (Optional)         | Allow the script to run with an older version of cURL                                    |
 | `-h`, `--help`                                 | N/A                     | `None`                     | Display help message                                                                     |
+
+> <sup>1</sup> For backwards compatibility, $SENSORTYPE can be used in place of $SENSOR_TYPE.
+
+### Sensor Types
+
+The following sensor types are available to download:
+
+| Sensor Image Name | Description |
+|:-------------|:------------|
+| `falcon-sensor` **(default)** | The Falcon sensor for Linux as a DaemonSet deployment |
+| `falcon-container` | The Falcon Container sensor for Linux |
+| `falcon-kac` | The Falcon Kubernetes Admission Controller |
+| `kpagent` | The Falcon Kubernetes Protection Agent |
 
 ### Example usage to download DaemonSet sensor
 

--- a/bash/containers/falcon-container-sensor-pull/README.md
+++ b/bash/containers/falcon-container-sensor-pull/README.md
@@ -2,6 +2,10 @@
 
 Use this bash script to pull the latest **Falcon Container** sensor, **Node Kernel Mode DaemonSet** sensor, **Kubernetes Admission Controller** or **Kubernetes Protection Agent** from the CrowdStrike container registry and push it to your local Docker registry or remote registries.
 
+> :warning: **Deprecation Warning**: Starting with version 2.0.0, the `SENSORTYPE` environment variable will be deprecated and replaced with `SENSOR_TYPE`. `SENSORTYPE` will still be supported for backwards compatibility, but will be removed in a future release. Please update your code to use `SENSOR_TYPE` to specify your sensor type.
+>
+> :warning: **Breaking Changes**: The following command line options have been removed and are no longer supported: `-n`, `--node`, `--kubernetes-admission-controller`, and `--kubernetes-protection-agent`. To update your code, use the `-t, --type` option to specify your sensor type. For example, to download the Kubernetes Protection Agent, use `--type kpagent`.
+
 ## Security recommendations
 
 ### Use cURL version 7.55.0 or later
@@ -55,18 +59,18 @@ Help Options:
 | `-f`, `--cid <FALCON_CID>`                     | `$FALCON_CID`           | `None` (Optional)          | CrowdStrike Customer ID (CID)                                                            |
 | `-u`, `--client-id <FALCON_CLIENT_ID>`         | `$FALCON_CLIENT_ID`     | `None` (Required)          | CrowdStrike API Client ID                                                                |
 | `-s`, `--client-secret <FALCON_CLIENT_SECRET>` | `$FALCON_CLIENT_SECRET` | `None` (Required)          | CrowdStrike API Client Secret                                                            |
-| `-r`, `--region <FALCON_CLOUD>`                | `$FALCON_CLOUD`         | `us-1` (Optional)          | CrowdStrike Region                                                                       |
+| `-r`, `--region <FALCON_CLOUD>`                | `$FALCON_CLOUD`         | `us-1` (Optional)          | CrowdStrike Region. Will try to autodiscover if not specified.                                                                       |
 | `-c`, `--copy <REGISTRY/NAMESPACE>`            | `$COPY`                 | `None` (Optional)          | Registry you want to copy the sensor image to. Example: `myregistry.com/mynamespace`     |
 | `-v`, `--version <SENSOR_VERSION>`             | `$SENSOR_VERSION`       | `None` (Optional)          | Specify sensor version to retrieve from the registry                                     |
 | `-p`, `--platform <SENSOR_PLATFORM>`           | `$SENSOR_PLATFORM`      | `None` (Optional)          | Specify sensor platform to retrieve from the registry                                    |
-| `-t`, `--type <SENSORTYPE>`                    | `$SENSOR_TYPE`<sup>1</sup>           | `falcon-sensor` (Optional) | Specify which sensor to download [`falcon-container`, `falcon-sensor`, `falcon-kac`, `kpagent`] ([see more details below](#sensor-types)) |
+| `-t`, `--type <SENSORTYPE>`                    | `$SENSOR_TYPE`<sup>1</sup>           | `falcon-container` (Optional) | Specify which sensor to download [`falcon-container`, `falcon-sensor`, `falcon-kac`, `kpagent`] ([see more details below](#sensor-types)) |
 | `--runtime`                                    | `$CONTAINER_TOOL`       | `docker` (Optional)        | Use a different container runtime [docker, podman, skopeo]. **Default is Docker**.       |
 | `--dump-credentials`                           | `$CREDS`                | `False` (Optional)         | Print registry credentials to stdout to copy/paste into container tools                  |
 | `--list-tags`                                  | `$LISTTAGS`             | `False` (Optional)         | List all tags available for the selected sensor                                          |
 | `--allow-legacy-curl`                          | `$ALLOW_LEGACY_CURL`    | `False` (Optional)         | Allow the script to run with an older version of cURL                                    |
 | `-h`, `--help`                                 | N/A                     | `None`                     | Display help message                                                                     |
 
-> <sup>1</sup> For backwards compatibility, $SENSORTYPE can be used in place of $SENSOR_TYPE.
+> <sup>1</sup> For backwards compatibility, $SENSORTYPE can still be used in place of $SENSOR_TYPE.
 
 ### Sensor Types
 
@@ -74,29 +78,43 @@ The following sensor types are available to download:
 
 | Sensor Image Name | Description |
 |:-------------|:------------|
-| `falcon-sensor` **(default)** | The Falcon sensor for Linux as a DaemonSet deployment |
-| `falcon-container` | The Falcon Container sensor for Linux |
+| `falcon-sensor` | The Falcon sensor for Linux as a DaemonSet deployment |
+| `falcon-container` **(default)** | The Falcon Container sensor for Linux |
 | `falcon-kac` | The Falcon Kubernetes Admission Controller |
 | `kpagent` | The Falcon Kubernetes Protection Agent |
 
-### Example usage to download DaemonSet sensor
+### Examples
 
-#### Example using `autodiscover`
+#### Example downloading the Falcon Kubernetes Admission Controller
 
-```terminal
+The following example will attempt to autodiscover the region and download the latest version of the Falcon Kubernetes Admission Controller container image.
+
+```shell
 ./falcon-container-sensor-pull.sh \
---client-id <ABCDEFG123456> \
---client-secret <ABCDEFG123456> \
---node
+--type falcon-kac \
+--client-id <FALCON_CLIENT_ID> \
+--client-secret <FALCON_CLIENT_SECRET>
 ```
 
-#### Example without using `autodiscover`
+#### Example downloading the Falcon Container sensor
 
-```terminal
+The following example will download the latest version of the Falcon Container sensor container image and copy it to another registry.
+
+```shell
 ./falcon-container-sensor-pull.sh \
---cid <ABCDEFG123456> \
---client-id <ABCDEFG123456> \
---client-secret <ABCDEFG123456> \
---region us-2 \
---node
+--client-id <FALCON_CLIENT_ID> \
+--client-secret <FALCON_CLIENT_SECRET> \
+--region us-1 \
+--copy myregistry.com/mynamespace
+```
+
+#### Example dumping credentials
+
+The following example will dump the credentials to stdout to copy/paste into container tools.
+
+```shell
+./falcon-container-sensor-pull.sh \
+--client-id <FALCON_CLIENT_ID> \
+--client-secret <FALCON_CLIENT_SECRET> \
+--dump-credentials
 ```

--- a/bash/containers/falcon-container-sensor-pull/README.md
+++ b/bash/containers/falcon-container-sensor-pull/README.md
@@ -4,9 +4,11 @@ Use this bash script to pull the latest **Falcon Container** sensor, **Node Kern
 
 ## Deprecation Warning :warning:
 
+1. **Default Sensor Type Change** : The default sensor type will be changed from `falcon-container` to `falcon-sensor`. This change is based off of feedback from our customers and is intended to simplify the usage of this script.
+
 1. **Environment Variable Deprecation** : The `SENSORTYPE` environment variable will be deprecated and replaced by `SENSOR_TYPE`. This update is intended to increase readability and maintain consistency in our environment variable naming convention.
 
-2. **Command Option Deprecation** : The command line options `-n, --node`, `--kubernetes-admission-controller`, and `--kubernetes-protection-agent` will be deprecated and replaced by a single option `-t, --type`. The new `-t, --type` option will allow you to specify the sensor type in a more straightforward and simplified manner.
+1. **Command Option Deprecation** : The command line options `-n, --node`, `--kubernetes-admission-controller`, and `--kubernetes-protection-agent` will be deprecated and replaced by a single option `-t, --type`. The new `-t, --type` option will allow you to specify the sensor type in a more straightforward and simplified manner.
 
 While these changes will be officially introduced in version 2.0.0, we will continue to support the deprecated environment variable and command options until that release. We strongly encourage you to adapt your usage to include the new `SENSOR_TYPE` environment variable and `-t, --type` command option to ensure a smooth transition when version 2.0.0 is released.
 
@@ -45,8 +47,9 @@ Optional Flags:
     -c, --copy <REGISTRY/NAMESPACE>   registry to copy image e.g. myregistry.com/mynamespace
     -v, --version <SENSOR_VERSION>    specify sensor version to retrieve from the registry
     -p, --platform <SENSOR_PLATFORM>  specify sensor platform to retrieve e.g x86_64, aarch64
-
     -t, --type <SENSOR_TYPE>          specify which sensor to download [falcon-container|falcon-sensor|falcon-kac|kpagent]
+                                      Default is falcon-container.
+
     --runtime                         use a different container runtime [docker, podman, skopeo]. Default is docker.
     --dump-credentials                print registry credentials to stdout to copy/paste into container tools.
     --list-tags                       list all tags available for the selected sensor
@@ -65,7 +68,7 @@ Help Options:
 | `-f`, `--cid <FALCON_CID>`                     | `$FALCON_CID`           | `None` (Optional)          | CrowdStrike Customer ID (CID)                                                            |
 | `-u`, `--client-id <FALCON_CLIENT_ID>`         | `$FALCON_CLIENT_ID`     | `None` (Required)          | CrowdStrike API Client ID                                                                |
 | `-s`, `--client-secret <FALCON_CLIENT_SECRET>` | `$FALCON_CLIENT_SECRET` | `None` (Required)          | CrowdStrike API Client Secret                                                            |
-| `-r`, `--region <FALCON_CLOUD>`                | `$FALCON_CLOUD`         | `us-1` (Optional)          | CrowdStrike Region. Will try to autodiscover if not specified.                                                                       |
+| `-r`, `--region <FALCON_CLOUD>`                | `$FALCON_CLOUD`         | `us-1` (Optional)          | CrowdStrike Region                                                                       |
 | `-c`, `--copy <REGISTRY/NAMESPACE>`            | `$COPY`                 | `None` (Optional)          | Registry you want to copy the sensor image to. Example: `myregistry.com/mynamespace`     |
 | `-v`, `--version <SENSOR_VERSION>`             | `$SENSOR_VERSION`       | `None` (Optional)          | Specify sensor version to retrieve from the registry                                     |
 | `-p`, `--platform <SENSOR_PLATFORM>`           | `$SENSOR_PLATFORM`      | `None` (Optional)          | Specify sensor platform to retrieve from the registry                                    |
@@ -75,7 +78,6 @@ Help Options:
 | `--list-tags`                                  | `$LISTTAGS`             | `False` (Optional)         | List all tags available for the selected sensor                                          |
 | `--allow-legacy-curl`                          | `$ALLOW_LEGACY_CURL`    | `False` (Optional)         | Allow the script to run with an older version of cURL                                    |
 | `-h`, `--help`                                 | N/A                     | `None`                     | Display help message                                                                     |
-
 
 ### Sensor Types
 
@@ -96,20 +98,21 @@ The following example will attempt to autodiscover the region and download the l
 
 ```shell
 ./falcon-container-sensor-pull.sh \
---type falcon-kac \
 --client-id <FALCON_CLIENT_ID> \
---client-secret <FALCON_CLIENT_SECRET>
+--client-secret <FALCON_CLIENT_SECRET> \
+--type falcon-kac
 ```
 
-#### Example downloading the Falcon Container sensor
+#### Example downloading the Falcon DaemonSet sensor
 
-The following example will download the latest version of the Falcon Container sensor container image and copy it to another registry.
+The following example will download the latest version of the Falcon DaemonSet sensor container image and copy it to another registry.
 
 ```shell
 ./falcon-container-sensor-pull.sh \
 --client-id <FALCON_CLIENT_ID> \
 --client-secret <FALCON_CLIENT_SECRET> \
---region us-1 \
+--region us-2 \
+--type falcon-sensor \
 --copy myregistry.com/mynamespace
 ```
 

--- a/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
+++ b/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
@@ -20,8 +20,9 @@ Optional Flags:
     -c, --copy <REGISTRY/NAMESPACE>   registry to copy image e.g. myregistry.com/mynamespace
     -v, --version <SENSOR_VERSION>    specify sensor version to retrieve from the registry
     -p, --platform <SENSOR_PLATFORM>  specify sensor platform to retrieve e.g x86_64, aarch64
-
     -t, --type <SENSOR_TYPE>          specify which sensor to download [falcon-container|falcon-sensor|falcon-kac|kpagent]
+                                      Default is falcon-container.
+
     --runtime                         use a different container runtime [docker, podman, skopeo]. Default is docker.
     --dump-credentials                print registry credentials to stdout to copy/paste into container tools.
     --list-tags                       list all tags available for the selected sensor
@@ -230,6 +231,7 @@ COPY=$(echo "$COPY" | tr '[:upper:]' '[:lower:]')
 # If not, default SENSOR_TYPE to falcon-container
 # *SENSORTYPE is deprecated and will be removed in a future release
 if [ -z "${SENSOR_TYPE}" ] && [ -z "${SENSORTYPE}" ]; then
+    deprecated "The default sensor type of falcon-container"
     SENSOR_TYPE="falcon-container"
 elif [ -z "${SENSOR_TYPE}" ] && [ -n "${SENSORTYPE}" ]; then
     deprecated "SENSORTYPE"

--- a/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
+++ b/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
@@ -21,9 +21,7 @@ Optional Flags:
     -v, --version <SENSOR_VERSION>    specify sensor version to retrieve from the registry
     -p, --platform <SENSOR_PLATFORM>  specify sensor platform to retrieve e.g x86_64, aarch64
 
-    -n, --node                        download node sensor instead of container sensor
-    --kubernetes-admission-controller download kubernetes admission controller instead of falcon sensor
-    --kubernetes-protection-agent     download kubernetes protection agent instead of falcon sensor
+    -t, --type <SENSOR_TYPE>          specify which sensor to download [falcon-container|falcon-sensor|falcon-kac|kpagent]
     --runtime                         use a different container runtime [docker, podman, skopeo]. Default is docker.
     --dump-credentials                print registry credentials to stdout to copy/paste into container tools.
     --list-tags                       list all tags available for the selected sensor
@@ -130,19 +128,10 @@ case "$1" in
         ALLOW_LEGACY_CURL=true
     fi
     ;;
-    -n|--node)
-    if [ -n "${1}" ]; then
-        SENSORTYPE="falcon-sensor"
-    fi
-    ;;
-    --kubernetes-admission-controller)
-    if [ -n "${1}" ]; then
-        SENSORTYPE="falcon-kac"
-    fi
-    ;;
-    --kubernetes-protection-agent)
-    if [ -n "${1}" ]; then
-        SENSORTYPE="kpagent"
+    -t|--type)
+    if [ -n "${2}" ]; then
+        SENSOR_TYPE="${2}"
+        shift
     fi
     ;;
     -h|--help)
@@ -214,10 +203,22 @@ SENSOR_VERSION=$(echo "$SENSOR_VERSION" | tr '[:upper:]' '[:lower:]')
 SENSOR_PLATFORM=$(echo "$SENSOR_PLATFORM" | tr '[:upper:]' '[:lower:]')
 COPY=$(echo "$COPY" | tr '[:upper:]' '[:lower:]')
 
-#Check if user wants to download DaemonSet Node Sensor
-if [ -z "$SENSORTYPE" ]; then
-    SENSORTYPE="falcon-container"
+# Check if SENSORTYPE or SENSOR_TYPE env var is set
+# If not, default SENSOR_TYPE to falcon-container
+# *SENSORTYPE is deprecated and will be removed in a future release
+if [ -z "${SENSOR_TYPE}" ] && [ -z "${SENSORTYPE}" ]; then
+    SENSOR_TYPE="falcon-container"
+elif [ -z "${SENSOR_TYPE}" ] && [ -n "${SENSORTYPE}" ]; then
+    SENSOR_TYPE="${SENSORTYPE}"
 fi
+
+# Check if SENSOR_TYPE is set to a valid value
+case "${SENSOR_TYPE}" in
+    falcon-container|falcon-sensor|falcon-kac|kpagent) ;;
+    *) die """
+    Unrecognized sensor type: ${SENSOR_TYPE}
+    Valid values are [falcon-container|falcon-sensor|falcon-kac|kpagent]""";;
+esac
 
 #Check all mandatory variables set
 VARIABLES="FALCON_CLIENT_ID FALCON_CLIENT_SECRET"
@@ -272,9 +273,9 @@ fi
 registry_opts=$(
     # Account for govcloud api mismatch
     if [ "${FALCON_CLOUD}" = "us-gov-1" ]; then
-        echo "$SENSORTYPE/govcloud"
+        echo "$SENSOR_TYPE/govcloud"
     else
-        echo "$SENSORTYPE/$FALCON_CLOUD"
+        echo "$SENSOR_TYPE/$FALCON_CLOUD"
     fi
 )
 
@@ -297,11 +298,11 @@ ART_USERNAME="fc-$cs_falcon_cid"
 sensor_name="falcon-sensor"
 repository_name="release/falcon-sensor"
 
-if [ "${SENSORTYPE}" = "falcon-kac" ]; then
+if [ "${SENSOR_TYPE}" = "falcon-kac" ]; then
     # overrides for KAC
     sensor_name="falcon-kac"
     repository_name="release/falcon-kac"
-elif [ "${SENSORTYPE}" = "kpagent" ]; then
+elif [ "${SENSOR_TYPE}" = "kpagent" ]; then
     # overrides for KPA
     ART_USERNAME="kp-$cs_falcon_cid"
     sensor_name="kpagent"
@@ -310,7 +311,7 @@ elif [ "${SENSORTYPE}" = "kpagent" ]; then
 fi
 
 #Set Docker token using the BEARER token captured earlier
-if [ "${SENSORTYPE}" = "kpagent" ]; then
+if [ "${SENSOR_TYPE}" = "kpagent" ]; then
     docker_api_token=$(curl_command "$cs_falcon_oauth_token" "https://$(cs_cloud)/kubernetes-protection/entities/integration/agent/v1?cluster_name=clustername&is_self_managed_cluster=true" | awk '/dockerAPIToken:/ {print $2}')
 else
     docker_api_token=$(curl_command "$cs_falcon_oauth_token" "https://$(cs_cloud)/container-security/entities/image-registry-credentials/v1" | json_value "token")

--- a/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
+++ b/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
@@ -37,6 +37,11 @@ die() {
     exit 1
 }
 
+# todo: Remove in next major release
+deprecated() {
+    echo "WARNING: $* is deprecated and will be removed in a future release"
+}
+
 cs_container() {
     case "${CONTAINER_TOOL}" in
         skopeo)      echo "skopeo";;
@@ -128,6 +133,24 @@ case "$1" in
         ALLOW_LEGACY_CURL=true
     fi
     ;;
+    -n|--node)
+    if [ -n "${1}" ]; then
+        deprecated "-n|--node"
+        SENSOR_TYPE="falcon-sensor"
+    fi
+    ;;
+    --kubernetes-admission-controller)
+    if [ -n "${1}" ]; then
+        deprecated "--kubernetes-admission-controller"
+        SENSOR_TYPE="falcon-kac"
+    fi
+    ;;
+    --kubernetes-protection-agent)
+    if [ -n "${1}" ]; then
+        deprecated "--kubernetes-protection-agent"
+        SENSOR_TYPE="kpagent"
+    fi
+    ;;
     -t|--type)
     if [ -n "${2}" ]; then
         SENSOR_TYPE="${2}"
@@ -209,6 +232,7 @@ COPY=$(echo "$COPY" | tr '[:upper:]' '[:lower:]')
 if [ -z "${SENSOR_TYPE}" ] && [ -z "${SENSORTYPE}" ]; then
     SENSOR_TYPE="falcon-container"
 elif [ -z "${SENSOR_TYPE}" ] && [ -n "${SENSORTYPE}" ]; then
+    deprecated "SENSORTYPE"
     SENSOR_TYPE="${SENSORTYPE}"
 fi
 


### PR DESCRIPTION
This pull request implements a significant refactor to the `falcon-container-sensor-pull.sh` script and the corresponding README to enhance usability and maintainability. The changes primarily revolve around how sensor types are selected for download.

**Changes Introduced:**

- Replaced the individual flags `-n`, `--node`, `--kubernetes-admission-controller`, and `--kubernetes-protection-agent` with a single option, `-t`, `--type <SENSOR_TYPE>`. This option allows users to specify which sensor to download with a more concise and maintainable syntax. 

- Ensured backward compatibility for the replaced flags. This update includes a depraction warning to prepare users for the future removal of the cli args.

- Added a detailed "Sensor Types" section to the README, providing users with a straightforward reference for available sensor types and their descriptions.

- Ensured backward compatibility with the deprecated `$SENSORTYPE` environment variable. This update includes a deprecation warning to prepare users for the future removal of `$SENSORTYPE`.

- Updated the shell script to validate the `SENSOR_TYPE` value against the list of valid sensor types. An unrecognized sensor type will now yield a descriptive error message, guiding users towards valid options.

**Benefits:**

- This update simplifies the selection of sensor types by replacing multiple flags with a single, intuitive flag.
  
- By providing a clear description of available sensor types in the README, this update enhances user understanding and facilitates easier selection of sensor types.

- The improved error messaging for invalid sensor types will reduce user confusion and help users troubleshoot issues more effectively.

By simplifying the process of selecting sensor types and enhancing the related documentation, this PR aims to improve user experience and facilitate future maintenance of the `falcon-container-sensor-pull.sh` script.