### PR TITLE
fix(migrate): set tls upfront + change log method

### DIFF
--- a/powershell/migrate/README.md
+++ b/powershell/migrate/README.md
@@ -12,7 +12,7 @@ The following **API scopes** are required:
 
 - **Sensor Download** [read]
 - **Host** [read,write]
-- **Sensor update policies** [write]
+- **Sensor update policies** [read,write]
 
 ## What Does It Do?
 

--- a/powershell/migrate/falcon_windows_migrate.ps1
+++ b/powershell/migrate/falcon_windows_migrate.ps1
@@ -1,6 +1,3 @@
-# Set TLS 1.2
-[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-
 <#
 .SYNOPSIS
 Migrate a sensor to another falcon cloud tenant.
@@ -1007,6 +1004,9 @@ function Invoke-FalconAuth([string] $BaseUrl, [hashtable] $Body, [string] $Falco
 }
 
 ### Start of Migration Script ###
+
+# Set TLS 1.2
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 if (([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
         [Security.Principal.WindowsBuiltInRole]::Administrator) -eq $false) {

--- a/powershell/migrate/falcon_windows_migrate.ps1
+++ b/powershell/migrate/falcon_windows_migrate.ps1
@@ -1,3 +1,6 @@
+# Set TLS 1.2
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
 <#
 .SYNOPSIS
 Migrate a sensor to another falcon cloud tenant.
@@ -454,23 +457,6 @@ function Invoke-FalconInstall ([string] $InstallParams, [string] $Tags, [bool] $
             $Message = "'CSFalconService' running. Falcon sensor is already installed."
             Write-MigrateLog $Message
             break
-        }
-        else {
-            if ([Net.ServicePointManager]::SecurityProtocol -notmatch 'Tls12') {
-                try {
-                    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-                }
-                catch {
-                    $Message = $_
-                    Write-MigrateLog $Message
-                    throw $Message
-                }
-            }
-            if (!($PSVersionTable.CLRVersion.ToString() -ge 3.5)) {
-                $Message = '.NET Framework 3.5 or newer is required'
-                Write-MigrateLog $Message
-                throw $Message
-            }
         }
 
         # If NewFalconCid is not provided, get it from the API
@@ -983,7 +969,7 @@ function Invoke-FalconAuth([string] $BaseUrl, [hashtable] $Body, [string] $Falco
 
         if (!$response) {
             $message = "Unhandled error occurred while authenticating to the CrowdStrike Falcon API. Error: $($_.Exception.Message)"
-            Write-FalconLog -Source 'Invoke-FalconAuth' -Message $message
+            Write-MigrateLog -Source 'Invoke-FalconAuth' -Message $message
             throw $message
         }
 
@@ -996,7 +982,7 @@ function Invoke-FalconAuth([string] $BaseUrl, [hashtable] $Body, [string] $Falco
                 }
                 else {
                     $message = 'Received a redirect but no X-Cs-Region header was provided. Unable to autodiscover the FalconCloud. Please set FalconCloud to the correct region.'
-                    Write-FalconLog -Source 'Invoke-FalconAuth' -Message $message
+                    Write-MigrateLog -Source 'Invoke-FalconAuth' -Message $message
                     throw $message
                 }
 
@@ -1006,13 +992,13 @@ function Invoke-FalconAuth([string] $BaseUrl, [hashtable] $Body, [string] $Falco
             }
             else {
                 $message = "Received a redirect. Please set FalconCloud to 'autodiscover' or the correct region."
-                Write-FalconLog -Source 'Invoke-FalconAuth' -Message $message
+                Write-MigrateLog -Source 'Invoke-FalconAuth' -Message $message
                 throw $message
             }
         }
         else {
             $message = "Received a $($response.StatusCode) response from $($BaseUrl)oauth2/token. Please check your credentials and try again. Error: $($response.StatusDescription)"
-            Write-FalconLog -Source 'Invoke-FalconAuth' -Message $message
+            Write-MigrateLog -Source 'Invoke-FalconAuth' -Message $message
             throw $message
         }
     }


### PR DESCRIPTION
This PR moves TLS 1.2 enablement to the top to ensure the endpoint can run the script. Also fixes an issue with using the wrong logging method.