### PR TITLE
fix: Adding error message on CS registry password api issue and optimizing cred-dump output

### DIFF
--- a/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
+++ b/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
@@ -373,7 +373,6 @@ $raw_docker_api_token
 
 Ensure the following:
   - Credentials are valid.
-  - Environment variables are set (not NULL).
   - Correct API Scopes are assigned (Falcon Images Download [read], Sensor Download [read], Kubernetes Protection [read])
   - Cloud Security is enabled in your tenant."
 fi

--- a/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
+++ b/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
@@ -344,9 +344,11 @@ fi
 
 #Set Docker token using the BEARER token captured earlier
 if [ "${SENSOR_TYPE}" = "kpagent" ]; then
-    docker_api_token=$(curl_command "$cs_falcon_oauth_token" "https://$(cs_cloud)/kubernetes-protection/entities/integration/agent/v1?cluster_name=clustername&is_self_managed_cluster=true" | awk '/dockerAPIToken:/ {print $2}')
+    raw_docker_api_token=$(curl_command "$cs_falcon_oauth_token" "https://$(cs_cloud)/kubernetes-protection/entities/integration/agent/v1?cluster_name=clustername&is_self_managed_cluster=true")
+    docker_api_token=$(echo "$raw_docker_api_token" | awk '/dockerAPIToken:/ {print $2}')
 else
-    docker_api_token=$(curl_command "$cs_falcon_oauth_token" "https://$(cs_cloud)/container-security/entities/image-registry-credentials/v1" | json_value "token")
+    raw_docker_api_token=$(curl_command "$cs_falcon_oauth_token" "https://$(cs_cloud)/container-security/entities/image-registry-credentials/v1" )
+    docker_api_token=$(echo "$raw_docker_api_token" | json_value "token")
 fi
 ART_PASSWORD=$(echo "$docker_api_token" | sed 's/ *$//g' | sed 's/^ *//g')
 
@@ -362,6 +364,26 @@ if [ "$PULLTOKEN" ]; then
     # shellcheck disable=SC2086
     IMAGE_PULL_TOKEN=$(printf '{"auths": { "registry.crowdstrike.com": { "auth": "%s" } } }' "$PARTIALPULLTOKEN" | base64 $BASE64_OPT)
     echo "Image Pull Token: ${IMAGE_PULL_TOKEN}"
+    exit 0
+fi
+
+if [ -z "$ART_PASSWORD" ] ; then
+    echo "===================="
+    echo "API Cloud Response:"
+    echo "$raw_docker_api_token"
+    echo "===================="
+    echo "ART_PASSWORD is NULL, Please check:"
+    echo "1 - Your credentials are valid"
+    echo "2 - Your variables are not NULL"
+    echo "3 - You are have using the correct API Scopes (Falcon Image Download [read], Sensor Download [read], Kubernetes Protection [read])"
+    echo "4 - You have Cloud Security enabled in your tenant"
+    die "Can't get the CrowdStrike registry password"
+fi
+
+if [ "$CREDS" ] ; then
+    echo "CS Registry Username: ${ART_USERNAME}"
+    echo "CS Registry Password: ${ART_PASSWORD}"
+    # quitting no need to perform a registry login
     exit 0
 fi
 
@@ -413,12 +435,6 @@ case "${CONTAINER_TOOL}" in
         LATESTSENSOR=$($CONTAINER_TOOL list-tags "docker://$cs_registry/$registry_opts/$repository_name" | grep "$SENSOR_VERSION" | grep "$SENSOR_PLATFORM" | grep -o "[0-9a-zA-Z_\.\-]*" | tail -1) ;;
         *)         die "Unrecognized option: ${CONTAINER_TOOL}";;
 esac
-
-if [ "$CREDS" ] ; then
-    echo "CS Registry Username: ${ART_USERNAME}"
-    echo "CS Registry Password: ${ART_PASSWORD}"
-    exit 0
-fi
 
 #Construct full image path
 FULLIMAGEPATH="$cs_registry/$registry_opts/$repository_name:${LATESTSENSOR}"

--- a/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
+++ b/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
@@ -368,16 +368,14 @@ if [ "$PULLTOKEN" ]; then
 fi
 
 if [ -z "$ART_PASSWORD" ] ; then
-    echo "===================="
-    echo "API Cloud Response:"
-    echo "$raw_docker_api_token"
-    echo "===================="
-    echo "ART_PASSWORD is NULL, Please check:"
-    echo "1 - Your credentials are valid"
-    echo "2 - Your variables are not NULL"
-    echo "3 - You are have using the correct API Scopes (Falcon Image Download [read], Sensor Download [read], Kubernetes Protection [read])"
-    echo "4 - You have Cloud Security enabled in your tenant"
-    die "Can't get the CrowdStrike registry password"
+    die "Failed to retrieve the CrowdStrike registry password. Response from API:
+$raw_docker_api_token
+
+Ensure the following:
+  - Credentials are valid.
+  - Environment variables are set (not NULL).
+  - Correct API Scopes are assigned (Falcon Images Download [read], Sensor Download [read], Kubernetes Protection [read])
+  - Cloud Security is enabled in your tenant."
 fi
 
 if [ "$CREDS" ] ; then


### PR DESCRIPTION
- Adding an error message when ART_PASSWORD is empty
Solving issues when ART_PASSWORD is empty, creating this error : `ERROR: /usr/bin/docker login failed. Error message: Error: Cannot perform an interactive login from a non TTY device` 
guiding the user about the source of the issue.

- Moved the credentials-dump before the docker login (no need to perform a docker login when we request a dump-credentials)