### PR TITLE
fix: allow sorting for kpagent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *~
 *DS_Store
 .vagrant
+.vscode


### PR DESCRIPTION
Fixes #226 

This PR introduces a new function that better manages listing/formatting tags. For reasons unknown to me at this point, kpagent does not return sorted versions 🤷🏼‍♂️ so we needed a way to solve that. With these changes, kpagent will return back it's tags in the same sorted fashion as the others do. 

Before:
```json
{
  "name" : "kpagent",
  "tags": [ "0.1473.0", 
"0.1647.0", 
"0.248.0", 
"0.43.24", 
"0.447.0", 
"0.457.0", 
"0.585.0", 
"0.69.3", 
"0.852.0", 
"0.917.0" ]
}
```

After:
```json
{
  "name" : "kpagent",
  "tags": [ "0.43.24", 
"0.69.3", 
"0.248.0", 
"0.447.0", 
"0.457.0", 
"0.585.0", 
"0.852.0", 
"0.917.0", 
"0.1473.0", 
"0.1647.0"]
}
```