### PR TITLE
feat: add support for listing tags for podman/skopeo

### DIFF
--- a/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
+++ b/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
@@ -294,7 +294,7 @@ else
     CONTAINER_TOOL=$(command -v "$CONTAINER_TOOL")
 fi
 
-if grep -qw "skopeo" "$CONTAINER_TOOL" && [ -z "${COPY}" ] ; then
+if grep -qw "skopeo" "$CONTAINER_TOOL" && [ -z "${COPY}" ] && [ -z "${LISTTAGS}" ] ; then
     echo "-c, --copy <REGISTRY/NAMESPACE> must also be set when using skopeo as a runtime"
     exit 1
 fi
@@ -422,28 +422,12 @@ if [ "${ERROR}" = "true" ]; then
 fi
 
 if [ "$LISTTAGS" ] ; then
-    case "${CONTAINER_TOOL}" in
-        *podman)
-        die "Please use docker runtime to list tags" ;;
-        *docker)
-        list_tags ;;
-        *skopeo)
-        die "Please use docker runtime to list tags" ;;
-        *)         die "Unrecognized option: ${CONTAINER_TOOL}";;
-    esac
+    list_tags
     exit 0
 fi
 
 #Get latest sensor version
-case "${CONTAINER_TOOL}" in
-        *podman)
-        LATESTSENSOR=$($CONTAINER_TOOL image search --list-tags --limit 100 "$cs_registry/$registry_opts/$repository_name" | grep "$SENSOR_VERSION" | grep "$SENSOR_PLATFORM" | tail -1 | cut -d" " -f3);;
-        *docker)
-        LATESTSENSOR=$(list_tags | awk -v RS=" " '{print}' | grep "$SENSOR_VERSION" | grep -o "[0-9a-zA-Z_\.\-]*" | tail -1);;
-        *skopeo)
-        LATESTSENSOR=$($CONTAINER_TOOL list-tags "docker://$cs_registry/$registry_opts/$repository_name" | grep "$SENSOR_VERSION" | grep "$SENSOR_PLATFORM" | grep -o "[0-9a-zA-Z_\.\-]*" | tail -1) ;;
-        *)         die "Unrecognized option: ${CONTAINER_TOOL}";;
-esac
+LATESTSENSOR=$(list_tags | awk -v RS=" " '{print}' | grep "$SENSOR_VERSION" | grep -o "[0-9a-zA-Z_\.\-]*" | tail -1)
 
 #Construct full image path
 FULLIMAGEPATH="$cs_registry/$registry_opts/$repository_name:${LATESTSENSOR}"


### PR DESCRIPTION
Fixes #234 

~~This commit refactors the code to allow any container tool to list tags and take advantage of the new list_tags function. This simplifies the case for listing tags as well as downloading tags. Since a container tool is no longer needed to query tags - we can omit those case statements.~~

### Update
The original commit removed the need of using container tools (podman/skopeo) natively to fetch the tags. While that approach was simpler in terms of formatting/output, it did introduce an additional authentication layer that is not necessary for those tools. The new commits now support fetching tags via all 3 runtimes using their respective ways to fetch tags. 

### What Changed
To keep things uniform, and to enhance the existing `--list-tags` output, I decided to control the JSON output itself. Working within the confines of bash/dash 😞 I came up with some functions to help properly fetch and format the output. 

So now we're going from this:
```json
{
  "name" : "kpagent",
  "tags": [ "0.43.24",
"0.69.3",
"0.248.0",
"0.447.0",
"0.457.0",
"0.585.0",
"0.852.0",
"0.917.0",
"0.1473.0",
"0.1647.0"]
}
```

To this:
```json
{
  "name": "kpagent",
  "tags": [
    "0.43.24",
    "0.69.3",
    "0.248.0",
    "0.447.0",
    "0.457.0",
    "0.585.0",
    "0.852.0",
    "0.917.0",
    "0.1473.0",
    "0.1647.0"
  ]
}
```