### PR TITLE
Added support to pass OAuth token.

### DIFF
--- a/bash/install/README.md
+++ b/bash/install/README.md
@@ -31,6 +31,10 @@ Ensure the following API scopes are enabled:
 export FALCON_CLIENT_ID="XXXXXXX"
 export FALCON_CLIENT_SECRET="YYYYYYYYY"
 ```
+**or**
+```bash
+export FALCON_OAUTH_TOKEN="eyJhb****"
+```
 
 The installer is AWS SSM aware, if `FALCON_CLIENT_ID` and `FALCON_CLIENT_SECRET` are not provided AND the script is running on an AWS instance, the script will try to get API credentials from the SSM store of the region.
 


### PR DESCRIPTION
## Description

This pull request introduces token support to enhance the security of the Falcon sensor download script. Previously, organisations/user were required to pass client ID and client secret, which posed a potential security risk. Now, users can leverage a token for authentication, reducing the risk of sensitive information exposure during the download process.

## Changes Made

- Added token support to the Falcon sensor download script.

## Motivation

The motivation behind this change is to mitigate the risk associated with passing client ID and client secret directly in the script. Using tokens provides a more secure method of authentication for organisations using this script.

## Usage

User can export token if token is passed client_id and client_secret is not required.

export FALCON_OAUTH_TOKEN="eyJhb****"