### PR TITLE
Add the param to get the correct CID depending the agent-type

### DIFF
--- a/bash/containers/falcon-container-sensor-pull/README.md
+++ b/bash/containers/falcon-container-sensor-pull/README.md
@@ -59,7 +59,7 @@ Optional Flags:
     --runtime                         use a different container runtime [docker, podman, skopeo]. Default is docker.
     --dump-credentials                print registry credentials to stdout to copy/paste into container tools.
     --get-pull-token                  get the pull token of the selected SENSOR_TYPE for Kubernetes.
-    --get-cid                         Get the CID assigned to the Falcon Client ID
+    --get-cid                         Get the CID assigned to the API Credentials.
     --list-tags                       list all tags available for the selected sensor
     --allow-legacy-curl               allow the script to run with an older version of curl
 
@@ -84,7 +84,7 @@ Help Options:
 | `--runtime`                                    | `$CONTAINER_TOOL`       | `docker` (Optional)        | Use a different container runtime [docker, podman, skopeo]. **Default is Docker**.       |
 | `--dump-credentials`                           | `$CREDS`                | `False` (Optional)         | Print registry credentials to stdout to copy/paste into container tools                  |
 | `--get-pull-token`                             | N/A                     | `None`                     | Get the pull token of the selected SENSOR_TYPE for Kubernetes.                           |
-| `--get-cid`                                    | N/A                     | `None`                     | Get the CID assigned to the Falcon Client ID                                             |
+| `--get-cid`                                    | N/A                     | `None`                     | Get the CID assigned to the API Credentials.                                             |
 | `--list-tags`                                  | `$LISTTAGS`             | `False` (Optional)         | List all tags available for the selected sensor                                          |
 | `--allow-legacy-curl`                          | `$ALLOW_LEGACY_CURL`    | `False` (Optional)         | Allow the script to run with an older version of cURL                                    |
 | `-h`, `--help`                                 | N/A                     | `None`                     | Display help message                                                                     |

--- a/bash/containers/falcon-container-sensor-pull/README.md
+++ b/bash/containers/falcon-container-sensor-pull/README.md
@@ -141,7 +141,7 @@ The following example will generate a pull token for the Falcon Container sensor
 
 #### Example getting the CID
 
-The following example will get the CID for the Falcon Sensor for use in Kubernetes.
+The following example will get the CID for the Falcon Sensor configuration for kubernetes deployment.
 
 ```shell
 ./falcon-container-sensor-pull.sh \

--- a/bash/containers/falcon-container-sensor-pull/README.md
+++ b/bash/containers/falcon-container-sensor-pull/README.md
@@ -59,6 +59,7 @@ Optional Flags:
     --runtime                         use a different container runtime [docker, podman, skopeo]. Default is docker.
     --dump-credentials                print registry credentials to stdout to copy/paste into container tools.
     --get-pull-token                  get the pull token of the selected SENSOR_TYPE for Kubernetes.
+    --get-cid                         Get the CID assigned to the Falcon Client ID
     --list-tags                       list all tags available for the selected sensor
     --allow-legacy-curl               allow the script to run with an older version of curl
 
@@ -83,6 +84,7 @@ Help Options:
 | `--runtime`                                    | `$CONTAINER_TOOL`       | `docker` (Optional)        | Use a different container runtime [docker, podman, skopeo]. **Default is Docker**.       |
 | `--dump-credentials`                           | `$CREDS`                | `False` (Optional)         | Print registry credentials to stdout to copy/paste into container tools                  |
 | `--get-pull-token`                             | N/A                     | `None`                     | Get the pull token of the selected SENSOR_TYPE for Kubernetes.                           |
+| `--get-cid`                                    | N/A                     | `None`                     | Get the CID assigned to the Falcon Client ID                                             |
 | `--list-tags`                                  | `$LISTTAGS`             | `False` (Optional)         | List all tags available for the selected sensor                                          |
 | `--allow-legacy-curl`                          | `$ALLOW_LEGACY_CURL`    | `False` (Optional)         | Allow the script to run with an older version of cURL                                    |
 | `-h`, `--help`                                 | N/A                     | `None`                     | Display help message                                                                     |
@@ -135,6 +137,18 @@ The following example will generate a pull token for the Falcon Container sensor
 --client-secret <FALCON_CLIENT_SECRET> \
 --type falcon-container \
 --get-pull-token
+```
+
+#### Example getting the CID
+
+The following example will get the CID for the Falcon Sensor for use in Kubernetes.
+
+```shell
+./falcon-container-sensor-pull.sh \
+--client-id <FALCON_CLIENT_ID> \
+--client-secret <FALCON_CLIENT_SECRET> \
+--type falcon-sensor \
+--get-cid
 ```
 
 #### Example dumping credentials

--- a/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
+++ b/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
@@ -25,7 +25,7 @@ Optional Flags:
     --runtime                         use a different container runtime [docker, podman, skopeo]. Default is docker.
     --dump-credentials                print registry credentials to stdout to copy/paste into container tools.
     --get-pull-token                  Get the pull token of the selected SENSOR_TYPE for Kubernetes.
-    --get-cid                         Get the CID assigned to the Falcon Client ID
+    --get-cid                         Get the CID assigned to the API Credentials.
     --list-tags                       list all tags available for the selected sensor type and platform(optional)
     --allow-legacy-curl               allow the script to run with an older version of curl
 
@@ -418,7 +418,7 @@ if [ "$GETCID" ]; then
     exit 0
 fi
 
-if [ ! "$LISTTAGS" ] && [ ! "$PULLTOKEN" ]; then
+if [ ! "$LISTTAGS" ] && [ ! "$PULLTOKEN" ] && [ ! "$GETIMAGEREPOTAG" ]; then
     echo "Using the following settings:"
     echo "Falcon Region:   $(cs_cloud)"
     echo "Falcon Registry: ${cs_registry}"

--- a/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
+++ b/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
@@ -317,7 +317,6 @@ cs_registry="registry.crowdstrike.com"
 if [ "${FALCON_CLOUD}" = "us-gov-1" ]; then
     cs_registry="registry.laggar.gcw.crowdstrike.com"
 fi
-FALCON_CID=$(echo "${FALCON_CID}" | cut -d'-' -f1 | tr '[:upper:]' '[:lower:]')
 SENSOR_VERSION=$(echo "$SENSOR_VERSION" | tr '[:upper:]' '[:lower:]')
 SENSOR_PLATFORM=$(echo "$SENSOR_PLATFORM" | tr '[:upper:]' '[:lower:]')
 COPY=$(echo "$COPY" | tr '[:upper:]' '[:lower:]')

--- a/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
+++ b/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
@@ -402,7 +402,7 @@ registry_opts=$(
 
 cs_falcon_cid_with_checksum=$(
     if [ -n "$FALCON_CID" ]; then
-        echo "$FALCON_CID" 
+        echo "$FALCON_CID"
     else
         cs_target_cid=$(curl_command "$cs_falcon_oauth_token" "https://$(cs_cloud)/sensors/queries/installers/ccid/v1")
         echo "$cs_target_cid" | tr -d '\n" ' | awk -F'[][]' '{print $2}'
@@ -410,7 +410,7 @@ cs_falcon_cid_with_checksum=$(
 )
 cs_falcon_cid=$(echo "$cs_falcon_cid_with_checksum" | cut -d'-' -f1 | tr '[:upper:]' '[:lower:]')
 
-if [ "$GETCID" ]; then 
+if [ "$GETCID" ]; then
     if [ "${SENSOR_TYPE}" = "kpagent" ]; then
         echo "${cs_falcon_cid}"
     else


### PR DESCRIPTION
Often DevOps team don't have an access to the Falcon Console, they need a way to get important values (like the CID) to setup the falcon-sensor/falcon-container/kpagent config.

a condition was added to check if the sensor type is kpagent as there is a special format (lowercase no checksum) compared to other sensor type.