### PR TITLE
Get image repository and latest tag without downloading image

### DIFF
--- a/bash/containers/falcon-container-sensor-pull/README.md
+++ b/bash/containers/falcon-container-sensor-pull/README.md
@@ -58,6 +58,7 @@ Optional Flags:
 
     --runtime                         use a different container runtime [docker, podman, skopeo]. Default is docker.
     --dump-credentials                print registry credentials to stdout to copy/paste into container tools.
+    --get-image-repo-tag              Get the image repository and latest tag for the specified SENSOR_TYPE
     --get-pull-token                  get the pull token of the selected SENSOR_TYPE for Kubernetes.
     --list-tags                       list all tags available for the selected sensor
     --allow-legacy-curl               allow the script to run with an older version of curl
@@ -82,6 +83,7 @@ Help Options:
 | `-t`, `--type <SENSOR_TYPE>`                   | `$SENSOR_TYPE`         | `falcon-container` (Optional) | Specify which sensor to download [`falcon-container`, `falcon-sensor`, `falcon-kac`, `falcon-snapshot`, `kpagent`] ([see more details below](#sensor-types)) |
 | `--runtime`                                    | `$CONTAINER_TOOL`       | `docker` (Optional)        | Use a different container runtime [docker, podman, skopeo]. **Default is Docker**.       |
 | `--dump-credentials`                           | `$CREDS`                | `False` (Optional)         | Print registry credentials to stdout to copy/paste into container tools                  |
+| `--get-image-repo-tag`                         | N/A                     | `None`                     | Get the image repository and latest tag for the specified SENSOR_TYPE                    |
 | `--get-pull-token`                             | N/A                     | `None`                     | Get the pull token of the selected SENSOR_TYPE for Kubernetes.                           |
 | `--list-tags`                                  | `$LISTTAGS`             | `False` (Optional)         | List all tags available for the selected sensor                                          |
 | `--allow-legacy-curl`                          | `$ALLOW_LEGACY_CURL`    | `False` (Optional)         | Allow the script to run with an older version of cURL                                    |
@@ -110,6 +112,18 @@ The following example will attempt to autodiscover the region and download the l
 --client-id <FALCON_CLIENT_ID> \
 --client-secret <FALCON_CLIENT_SECRET> \
 --type falcon-kac
+```
+
+#### Example getting the full image path for the Falcon DaemonSet sensor
+
+The following example will print the image repository path with the latest image tag of the Falcon DaemonSet sensor.
+
+```shell
+./falcon-container-sensor-pull.sh \
+--client-id <FALCON_CLIENT_ID> \
+--client-secret <FALCON_CLIENT_SECRET> \
+--type falcon-sensor \
+--get-image-repo-tag
 ```
 
 #### Example downloading the Falcon DaemonSet sensor

--- a/bash/containers/falcon-container-sensor-pull/README.md
+++ b/bash/containers/falcon-container-sensor-pull/README.md
@@ -81,11 +81,11 @@ Help Options:
 | `-c`, `--copy <REGISTRY/NAMESPACE>`            | `$COPY`                 | `None` (Optional)          | Registry you want to copy the sensor image to. Example: `myregistry.com/mynamespace`     |
 | `-v`, `--version <SENSOR_VERSION>`             | `$SENSOR_VERSION`       | `None` (Optional)          | Specify sensor version to retrieve from the registry                                     |
 | `-p`, `--platform <SENSOR_PLATFORM>`           | `$SENSOR_PLATFORM`      | `None` (Optional)          | Specify sensor platform to retrieve from the registry                                    |
-| `-t`, `--type <SENSOR_TYPE>`                   | `$SENSOR_TYPE`         | `falcon-container` (Optional) | Specify which sensor to download [`falcon-container`, `falcon-sensor`, `falcon-kac`, `falcon-snapshot`, `kpagent`] ([see more details below](#sensor-types)) |
+| `-t`, `--type <SENSOR_TYPE>`                   | `$SENSOR_TYPE`          | `falcon-container` (Optional) | Specify which sensor to download [`falcon-container`, `falcon-sensor`, `falcon-kac`, `falcon-snapshot`, `kpagent`] ([see more details below](#sensor-types)) |
 | `--runtime`                                    | `$CONTAINER_TOOL`       | `docker` (Optional)        | Use a different container runtime [docker, podman, skopeo]. **Default is Docker**.       |
 | `--dump-credentials`                           | `$CREDS`                | `False` (Optional)         | Print registry credentials to stdout to copy/paste into container tools                  |
-| `--get-image-repo-tag`                         | N/A                     | `None`                     | Get the image repository and latest tag for the specified SENSOR_TYPE                    |
-| `--get-pull-token`                             | N/A                     | `None`                     | Get the pull token of the selected SENSOR_TYPE for Kubernetes.                           |
+| `--get-image-path`                             | N/A                     | `None`                     | Get the full image path including the registry, repository, and latest tag for the specified `SENSOR_TYPE`. |
+| `--get-pull-token`                             | N/A                     | `None`                     | Get the pull token of the selected `SENSOR_TYPE` for Kubernetes.                         |
 | `--get-cid`                                    | N/A                     | `None`                     | Get the CID assigned to the API Credentials.                                             |
 | `--list-tags`                                  | `$LISTTAGS`             | `False` (Optional)         | List all tags available for the selected sensor                                          |
 | `--allow-legacy-curl`                          | `$ALLOW_LEGACY_CURL`    | `False` (Optional)         | Allow the script to run with an older version of cURL                                    |

--- a/bash/containers/falcon-container-sensor-pull/README.md
+++ b/bash/containers/falcon-container-sensor-pull/README.md
@@ -58,7 +58,7 @@ Optional Flags:
 
     --runtime                         use a different container runtime [docker, podman, skopeo]. Default is docker.
     --dump-credentials                print registry credentials to stdout to copy/paste into container tools.
-    --get-image-repo-tag              Get the image repository and latest tag for the specified SENSOR_TYPE
+    --get-image-path                  Get the full image path including the registry, repository, and latest tag for the specified SENSOR_TYPE.
     --get-pull-token                  get the pull token of the selected SENSOR_TYPE for Kubernetes.
     --get-cid                         Get the CID assigned to the API Credentials.
     --list-tags                       list all tags available for the selected sensor
@@ -125,7 +125,7 @@ The following example will print the image repository path with the latest image
 --client-id <FALCON_CLIENT_ID> \
 --client-secret <FALCON_CLIENT_SECRET> \
 --type falcon-sensor \
---get-image-repo-tag
+--get-image-path
 ```
 
 #### Example downloading the Falcon DaemonSet sensor

--- a/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
+++ b/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
@@ -24,7 +24,7 @@ Optional Flags:
 
     --runtime                         use a different container runtime [docker, podman, skopeo]. Default is docker.
     --dump-credentials                print registry credentials to stdout to copy/paste into container tools.
-    --get-image-repo-tag              Get the image repository and latest tag for the specified SENSOR_TYPE
+    --get-image-path                  Get the full image path including the registry, repository, and latest tag for the specified SENSOR_TYPE.
     --get-pull-token                  Get the pull token of the selected SENSOR_TYPE for Kubernetes.
     --get-cid                         Get the CID assigned to the API Credentials.
     --list-tags                       list all tags available for the selected sensor type and platform(optional)
@@ -116,9 +116,9 @@ while [ $# != 0 ]; do
                 CREDS=true
             fi
             ;;
-        --get-image-repo-tag)
+        --get-image-path)
             if [ -n "${1}" ]; then
-                GETIMAGEREPOTAG=true
+                GETIMAGEPATH=true
             fi
             ;;
         --get-pull-token)
@@ -424,7 +424,7 @@ if [ "$GETCID" ]; then
     exit 0
 fi
 
-if [ ! "$LISTTAGS" ] && [ ! "$PULLTOKEN" ] && [ ! "$GETIMAGEREPOTAG" ]; then
+if [ ! "$LISTTAGS" ] && [ ! "$PULLTOKEN" ] && [ ! "$GETIMAGEPATH" ]; then
     echo "Using the following settings:"
     echo "Falcon Region:   $(cs_cloud)"
     echo "Falcon Registry: ${cs_registry}"
@@ -518,7 +518,7 @@ LATESTSENSOR=$(list_tags | awk -v RS=" " '{print}' | grep "$SENSOR_VERSION" | gr
 #Construct full image path
 FULLIMAGEPATH="$cs_registry/$registry_opts/$repository_name:${LATESTSENSOR}"
 
-if [ "$GETIMAGEREPOTAG" ]; then
+if [ "$GETIMAGEPATH" ]; then
     echo "${FULLIMAGEPATH}"
     exit 0
 fi

--- a/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
+++ b/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
@@ -24,6 +24,7 @@ Optional Flags:
 
     --runtime                         use a different container runtime [docker, podman, skopeo]. Default is docker.
     --dump-credentials                print registry credentials to stdout to copy/paste into container tools.
+    --get-image-repo-tag              Get the image repository and latest tag for the specified SENSOR_TYPE
     --get-pull-token                  Get the pull token of the selected SENSOR_TYPE for Kubernetes.
     --list-tags                       list all tags available for the selected sensor type and platform(optional)
     --allow-legacy-curl               allow the script to run with an older version of curl
@@ -112,6 +113,11 @@ while [ $# != 0 ]; do
         --dump-credentials)
             if [ -n "${1}" ]; then
                 CREDS=true
+            fi
+            ;;
+        --get-image-repo-tag)
+            if [ -n "${1}" ]; then
+                GETIMAGEREPOTAG=true
             fi
             ;;
         --get-pull-token)
@@ -496,6 +502,11 @@ LATESTSENSOR=$(list_tags | awk -v RS=" " '{print}' | grep "$SENSOR_VERSION" | gr
 
 #Construct full image path
 FULLIMAGEPATH="$cs_registry/$registry_opts/$repository_name:${LATESTSENSOR}"
+
+if [ "$GETIMAGEREPOTAG" ]; then
+    echo "${FULLIMAGEPATH}"
+    exit 0
+fi
 
 if grep -qw "skopeo" "$CONTAINER_TOOL"; then
     "$CONTAINER_TOOL" copy "docker://$FULLIMAGEPATH" "docker://$COPY/$repository_name:$LATESTSENSOR"


### PR DESCRIPTION
Get image repository and latest tag without downloading image or listing all tags
Today it's not possible to get the image full path info without downloading the image.

really simple to use for end users to get the correct image path (which is useful also for automation).