### PR TITLE
fix(bash_install): fix issue when installing with ubuntu 14

### DIFF
--- a/bash/install/falcon-linux-install.sh
+++ b/bash/install/falcon-linux-install.sh
@@ -269,7 +269,13 @@ os_install_package() {
             DEBIAN_FRONTEND=noninteractive apt-get -qq install -y "$pkg" >/dev/null
             ;;
         Ubuntu)
-            DEBIAN_FRONTEND=noninteractive apt-get -qq install -y "$pkg" >/dev/null
+            # If this is ubuntu 14, we need to use dpkg instead
+            if [ "${cs_os_version}" -eq 14 ]; then
+                DEBIAN_FRONTEND=noninteractive dpkg -i "$pkg" > /dev/null 2>&1 || true # ignore dep errors
+                DEBIAN_FRONTEND=noninteractive apt-get -qq install -f -y >/dev/null
+            else
+                DEBIAN_FRONTEND=noninteractive apt-get -qq install -y "$pkg" >/dev/null
+            fi
             ;;
         *)
             die "Unrecognized OS: ${os_name}"

--- a/bash/install/falcon-linux-install.sh
+++ b/bash/install/falcon-linux-install.sh
@@ -271,7 +271,7 @@ os_install_package() {
         Ubuntu)
             # If this is ubuntu 14, we need to use dpkg instead
             if [ "${cs_os_version}" -eq 14 ]; then
-                DEBIAN_FRONTEND=noninteractive dpkg -i "$pkg" > /dev/null 2>&1 || true # ignore dep errors
+                DEBIAN_FRONTEND=noninteractive dpkg -i "$pkg" >/dev/null 2>&1 || true # ignore dep errors
                 DEBIAN_FRONTEND=noninteractive apt-get -qq install -f -y >/dev/null
             else
                 DEBIAN_FRONTEND=noninteractive apt-get -qq install -y "$pkg" >/dev/null


### PR DESCRIPTION
Fixes #273

This issue presents itself with very old versions of Apt < 1.1. To address this, the traditional way to install a local deb package was to use dpkg first, which would then error if any deps are needed, which is true in our case. Then afterwards you could install all with apt-get install -f flag.