### PR TITLE
fix(pwsh): remove toLower func for policy name

### DIFF
--- a/powershell/install/falcon_windows_install.ps1
+++ b/powershell/install/falcon_windows_install.ps1
@@ -460,7 +460,7 @@ process {
     # Get sensor version from policy
     $message = "Retrieving sensor policy details for '$($SensorUpdatePolicyName)'"
     Write-FalconLog 'GetPolicy' $message
-    $filter = "platform_name:'Windows'+name.raw:'$($SensorUpdatePolicyName.ToLower())'"
+    $filter = "platform_name:'Windows'+name.raw:'$($SensorUpdatePolicyName)'"
     $url = "${BaseUrl}/policy/combined/sensor-update/v2?filter=$([System.Web.HttpUtility]::UrlEncode($filter)))"
     $policy_scope = @{
         'Sensor update policies' = @('Read')

--- a/powershell/migrate/falcon_windows_migrate.ps1
+++ b/powershell/migrate/falcon_windows_migrate.ps1
@@ -475,7 +475,7 @@ function Invoke-FalconInstall ([hashtable] $WebRequestParams, [string] $InstallP
         # Get sensor version from policy
         $message = "Retrieving sensor policy details for '$($SensorUpdatePolicyName)'"
         Write-FalconLog -Source 'Invoke-FalconInstall' -Message $message
-        $filter = "platform_name:'Windows'+name.raw:'$($SensorUpdatePolicyName.ToLower())'"
+        $filter = "platform_name:'Windows'+name.raw:'$($SensorUpdatePolicyName)'"
         $url = "${newBaseUrl}/policy/combined/sensor-update/v2?filter=$([System.Web.HttpUtility]::UrlEncode($filter)))"
         $policy_scope = @{
             'Sensor update policies' = @('Read')


### PR DESCRIPTION
Fixes #276

This PR removes the .ToLower() from the $SensorUpdatePolicyName as it is not needed due to name.raw field being case sensitive.