### PR TITLE
Adds functionality to hide host from the Crowdstrike console when uninstalling.

### DIFF
--- a/bash/install/README.md
+++ b/bash/install/README.md
@@ -40,9 +40,7 @@ export FALCON_CLIENT_SECRET="YYYYYYYYY"
 
 The installer is AWS SSM aware, if `FALCON_CLIENT_ID` and `FALCON_CLIENT_SECRET` are not provided AND the script is running on an AWS instance, the script will try to get API credentials from the SSM store of the region.
 
-### Additional Configuration
-
-Optional environment variables that can be exported:
+### Install
 
 ```terminal
 FALCON_CID                        (default: auto)
@@ -63,7 +61,9 @@ GET_ACCESS_TOKEN                  (default: false)   possible values: [true|fals
 FALCON_REMOVE_HOST                (default: true)
 ```
 
-**Run the script**:
+***Examples***:
+
+To download and run the script:
 
 ```bash
 curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.3.3/bash/install/falcon-linux-install.sh | bash
@@ -85,6 +85,47 @@ or
 
 ```bash
 bash falcon-linux-install.sh
+```
+
+### Uninstall
+
+```terminal
+Uninstalls the CrowdStrike Falcon Sensor from Linux operating systems.
+
+The script recognizes the following environmental variables:
+
+    - FALCON_CLIENT_ID                  (default: unset)
+        Your CrowdStrike Falcon API client ID. Required if FALCON_REMOVE_HOST is 'true'.
+
+    - FALCON_CLIENT_SECRET              (default: unset)
+        Your CrowdStrike Falcon API client secret. Required if FALCON_REMOVE_HOST is 'true'.
+
+    - FALCON_REMOVE_HOST                (default: unset)
+        Determines whether the host should be removed from the Falcon console after uninstalling the sensor.
+        Accepted values are ['true', 'false'].
+
+    - FALCON_APH                        (default: unset)
+        The proxy host for the sensor to use when communicating with CrowdStrike.
+
+    - FALCON_APP                        (default: unset)
+        The proxy port for the sensor to use when communicating with CrowdStrike.
+```
+
+***Examples***:
+
+To download and run the script:
+
+```bash
+curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.3.3/bash/install/falcon-linux-uninstall.sh | bash
+```
+
+Uninstall and remove the host from the Falcon console:
+
+```bash
+export FALCON_CLIENT_ID="XXXXXXX"
+export FALCON_CLIENT_SECRET="YYYYYYYYY"
+export FALCON_REMOVE_HOST="true"
+curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.3.3/bash/install/falcon-linux-uninstall.sh | bash
 ```
 
 ## Troubleshooting

--- a/bash/install/README.md
+++ b/bash/install/README.md
@@ -25,14 +25,22 @@ Ensure the following API scopes are enabled:
 
 ## Configuration
 
-**Export the required environment variables:**
+### Setting up Authentication
+
+#### Using Client ID and Client Secret
+
+Export the required environment variables:
 
 ```bash
 export FALCON_CLIENT_ID="XXXXXXX"
 export FALCON_CLIENT_SECRET="YYYYYYYYY"
 ```
 
+#### Using AWS SSM
+
 The installer is AWS SSM aware, if `FALCON_CLIENT_ID` and `FALCON_CLIENT_SECRET` are not provided AND the script is running on an AWS instance, the script will try to get API credentials from the SSM store of the region.
+
+### Additional Configuration
 
 Optional environment variables that can be exported:
 
@@ -51,6 +59,8 @@ FALCON_BILLING                    (default: default) possible values: [default|m
 FALCON_BACKEND                    (default: auto)    possible values: [auto|bpf|kernel]
 FALCON_TRACE                      (default: none)    possible values: [none|err|warn|info|debug]
 ALLOW_LEGACY_CURL                 (default: false)
+GET_ACCESS_TOKEN                  (default: false)   possible values: [true|false]
+FALCON_REMOVE_HOST                (default: true)
 ```
 
 **Run the script**:

--- a/bash/install/falcon-linux-uninstall.sh
+++ b/bash/install/falcon-linux-uninstall.sh
@@ -4,6 +4,21 @@ print_usage() {
     cat <<EOF
 This script removes the CrowdStrike Falcon Sensor for Linux from the operating system.
 
+Crowdstrike API credentials are needed to remove host from the Falcon console
+
+    - FALCON_CLIENT_ID
+    - FALCON_CLIENT_SECRET
+    or 
+    - FALCON_ACCESS_TOKEN               (default: unset)
+    - FALCON_CLOUD                      (default: auto)
+
+
+Optional:
+    - GET_ACCESS_TOKEN                  (default: false)   possible values: [true|false
+    - FALCON_APH                        (default: unset)
+    - FALCON_APP                        (default: unset)
+    - FALCON_REMOVE_HOST                (default: true)
+
 EOF
 }
 
@@ -15,6 +30,11 @@ main() {
     echo -n 'Removing Falcon Sensor  ... '
     cs_sensor_remove
     echo '[ Ok ]'
+    if [ -z "$FALCON_REMOVE_HOST" ] || [ "${FALCON_REMOVE_HOST}" = "true" ]; then
+        echo -n 'Removing host from console ... '
+        cs_remove_host_from_console
+        echo '[ Ok ] '
+    fi
     echo 'Falcon Sensor removed successfully.'
 }
 
@@ -37,5 +57,176 @@ cs_sensor_remove() {
 
     remove_package "falcon-sensor"
 }
+
+cs_remove_host_from_console() {
+    if [ "$aid" = "" ]; then
+        echo 'unable to find aid'
+    else
+        curl_command -X "POST" "https://$(cs_cloud)/devices/entities/devices-actions/v2?action_name=hide_host" -d "{    \"ids\": [    \"$aid\"  ]}" -H 'Content-Type: application/json'
+        handle_curl_error $?
+    fi
+}
+
+cs_cloud() {
+    case "${cs_falcon_cloud}" in
+    us-1) echo "api.crowdstrike.com" ;;
+    us-2) echo "api.us-2.crowdstrike.com" ;;
+    eu-1) echo "api.eu-1.crowdstrike.com" ;;
+    us-gov-1) echo "api.laggar.gcw.crowdstrike.com" ;;
+    *) die "Unrecognized Falcon Cloud: ${cs_falcon_cloud}" ;;
+    esac
+}
+
+if ! test -f /opt/CrowdStrike/falconctl; then
+    echo "Falcon sensor is not installed."
+    exit 1
+fi
+
+old_curl=$(
+    if ! command -v curl >/dev/null 2>&1; then
+        die "The 'curl' command is missing. Please install it before continuing. Aborting..."
+    fi
+
+    version=$(curl --version | head -n 1 | awk '{ print $2 }')
+    minimum="7.55"
+
+    # Check if the version is less than the minimum
+    if printf "%s\n" "$version" "$minimum" | sort -V -C; then
+        echo 0
+    else
+        echo 1
+    fi
+)
+
+curl_command() {
+    # Dash does not support arrays, so we have to pass the args as separate arguments
+    set -- "$@"
+
+    if [ "$old_curl" -eq 0 ]; then
+        curl -s -x "$proxy" -L -H "Authorization: Bearer ${cs_falcon_oauth_token}" "$@"
+    else
+        echo "Authorization: Bearer ${cs_falcon_oauth_token}" | curl -s -x "$proxy" -L -H @- "$@"
+    fi
+}
+
+handle_curl_error() {
+    if [ "$1" = "28" ]; then
+        err_msg="Operation timed out (exit code 28)."
+        if [ -n "$proxy" ]; then
+            err_msg="$err_msg A proxy was used to communicate ($proxy). Please check your proxy settings."
+        fi
+        die "$err_msg"
+    fi
+
+    if [ "$1" = "5" ]; then
+        err_msg="Couldn't resolve proxy (exit code 5). The address ($proxy) of the given proxy host could not be resolved. Please check your proxy settings."
+        die "$err_msg"
+    fi
+
+    if [ "$1" = "7" ]; then
+        err_msg="Failed to connect to host (exit code 7). Host found, but unable to open connection with host."
+        if [ -n "$proxy" ]; then
+            err_msg="$err_msg A proxy was used to communicate ($proxy). Please check your proxy settings."
+        fi
+        die "$err_msg"
+    fi
+}
+
+json_value() {
+    KEY=$1
+    num=$2
+    awk -F"[,:}]" '{for(i=1;i<=NF;i++){if($i~/'"$KEY"'\042/){print $(i+1)}}}' | tr -d '"' | sed -n "${num}p"
+}
+
+die() {
+    echo "Fatal error: $*" >&2
+    exit 1
+}
+
+cs_falcon_cloud=$(
+    if [ -n "$FALCON_CLOUD" ]; then
+        echo "$FALCON_CLOUD"
+    else
+        # Auto-discovery is using us-1 initially
+        echo "us-1"
+    fi
+)
+
+response_headers=$(mktemp)
+
+# shellcheck disable=SC2001
+proxy=$(
+    proxy=""
+    if [ -n "$FALCON_APH" ]; then
+        proxy="$(echo "$FALCON_APH" | sed "s|http.*://||")"
+
+        if [ -n "$FALCON_APP" ]; then
+            proxy="$proxy:$FALCON_APP"
+        fi
+    fi
+
+    if [ -n "$proxy" ]; then
+        # Remove redundant quotes
+        proxy="$(echo "$proxy" | sed "s/[\'\"]//g")"
+        proxy="http://$proxy"
+    fi
+    echo "$proxy"
+)
+
+cs_falcon_client_id=$(
+    if [ -n "$FALCON_CLIENT_ID" ]; then
+        echo "$FALCON_CLIENT_ID"
+    elif [ -n "$aws_instance" ]; then
+        aws_ssm_parameter "FALCON_CLIENT_ID" | json_value Value 1
+    else
+        die "Missing FALCON_CLIENT_ID environment variable. Please provide your OAuth2 API Client ID for authentication with CrowdStrike Falcon platform. Establishing and retrieving OAuth2 API credentials can be performed at https://falcon.crowdstrike.com/support/api-clients-and-keys."
+    fi
+)
+
+cs_falcon_client_secret=$(
+    if [ -n "$FALCON_CLIENT_SECRET" ]; then
+        echo "$FALCON_CLIENT_SECRET"
+    elif [ -n "$aws_instance" ]; then
+        aws_ssm_parameter "FALCON_CLIENT_SECRET" | json_value Value 1
+    else
+        die "Missing FALCON_CLIENT_SECRET environment variable. Please provide your OAuth2 API Client Secret for authentication with CrowdStrike Falcon platform. Establishing and retrieving OAuth2 API credentials can be performed at https://falcon.crowdstrike.com/support/api-clients-and-keys."
+    fi
+)
+
+cs_falcon_oauth_token=$(
+    token_result=$(echo "client_id=$cs_falcon_client_id&client_secret=$cs_falcon_client_secret" |
+        curl -X POST -s -x "$proxy" -L "https://$(cs_cloud)/oauth2/token" \
+            -H 'Content-Type: application/x-www-form-urlencoded; charset=utf-8' \
+            -H 'User-Agent: crowdstrike-falcon-scripts/1.3.3' \
+            --dump-header "${response_headers}" \
+            --data @-)
+
+    handle_curl_error $?
+
+    token=$(echo "$token_result" | json_value "access_token" | sed 's/ *$//g' | sed 's/^ *//g')
+    if [ -z "$token" ]; then
+        die "Unable to obtain CrowdStrike Falcon OAuth Token. Response was $token_result"
+    fi
+
+    echo "$token"
+)
+
+region_hint=$(grep -i ^x-cs-region: "$response_headers" | head -n 1 | tr '[:upper:]' '[:lower:]' | tr -d '\r' | sed 's/^x-cs-region: //g')
+rm "${response_headers}"
+
+if [ -z "${FALCON_CLOUD}" ]; then
+    if [ -z "${region_hint}" ]; then
+        die "Unable to obtain region hint from CrowdStrike Falcon OAuth API, Please provide FALCON_CLOUD environment variable as an override."
+    fi
+    cs_falcon_cloud="${region_hint}"
+else
+    if [ -n "$FALCON_ACCESS_TOKEN" ]; then
+        :
+    elif [ "x${FALCON_CLOUD}" != "x${region_hint}" ]; then
+        echo "WARNING: FALCON_CLOUD='${FALCON_CLOUD}' environment variable specified while credentials only exists in '${region_hint}'" >&2
+    fi
+fi
+
+aid="$(/opt/CrowdStrike/falconctl -g --aid | cut -c 6- | rev | cut -c 3- | rev)"
 
 main "$@"

--- a/bash/install/falcon-linux-uninstall.sh
+++ b/bash/install/falcon-linux-uninstall.sh
@@ -8,10 +8,6 @@ Crowdstrike API credentials are needed to remove host from the Falcon console
 
     - FALCON_CLIENT_ID
     - FALCON_CLIENT_SECRET
-    or 
-    - FALCON_ACCESS_TOKEN               (default: unset)
-    - FALCON_CLOUD                      (default: auto)
-
 
 Optional:
     - GET_ACCESS_TOKEN                  (default: false)   possible values: [true|false

--- a/bash/install/falcon-linux-uninstall.sh
+++ b/bash/install/falcon-linux-uninstall.sh
@@ -65,11 +65,11 @@ cs_remove_host_from_console() {
 
 cs_cloud() {
     case "${cs_falcon_cloud}" in
-    us-1) echo "api.crowdstrike.com" ;;
-    us-2) echo "api.us-2.crowdstrike.com" ;;
-    eu-1) echo "api.eu-1.crowdstrike.com" ;;
-    us-gov-1) echo "api.laggar.gcw.crowdstrike.com" ;;
-    *) die "Unrecognized Falcon Cloud: ${cs_falcon_cloud}" ;;
+        us-1) echo "api.crowdstrike.com" ;;
+        us-2) echo "api.us-2.crowdstrike.com" ;;
+        eu-1) echo "api.eu-1.crowdstrike.com" ;;
+        us-gov-1) echo "api.laggar.gcw.crowdstrike.com" ;;
+        *) die "Unrecognized Falcon Cloud: ${cs_falcon_cloud}" ;;
     esac
 }
 


### PR DESCRIPTION
This PR adds the functionality to the bash script to remove the respective host from the Crowdstrike console when uninstalling the Falcon sensor.

#275