### PR TITLE
Add functionality to bash scripts to use a pre-generated auth token to authenticate with the Crowdstrike API

### DIFF
--- a/bash/install/README.md
+++ b/bash/install/README.md
@@ -36,6 +36,26 @@ export FALCON_CLIENT_ID="XXXXXXX"
 export FALCON_CLIENT_SECRET="YYYYYYYYY"
 ```
 
+#### Using an Access Token
+
+You can also specify a Falcon access token if doing a batch install across multiple machines to prevent the need to call the token endpoint multiple times. If using an access token to authenticate, you ***MUST*** also provide `FALCON_CLOUD`:
+
+```bash
+export FALCON_ACCESS_TOKEN="XXXXXXXX"
+export FALCON_CLOUD="us-1"
+```
+
+> [!NOTE]
+> If you need to retrieve an access token, run the script with the `GET_ACCESS_TOKEN` environment variable set to `true`. The Falcon sensor will NOT be installed while this variable is set.
+>
+> ```bash
+> export FALCON_CLIENT_ID="XXXXXXX"
+> export FALCON_CLIENT_SECRET="YYYYYYYYY"
+> export GET_ACCESS_TOKEN="true"
+> ```
+>
+> The script will output the access token to the console.
+
 #### Using AWS SSM
 
 The installer is AWS SSM aware, if `FALCON_CLIENT_ID` and `FALCON_CLIENT_SECRET` are not provided AND the script is running on an AWS instance, the script will try to get API credentials from the SSM store of the region.

--- a/bash/install/README.md
+++ b/bash/install/README.md
@@ -25,14 +25,22 @@ Ensure the following API scopes are enabled:
 
 ## Configuration
 
-**Export the required environment variables:**
+### Setting up Authentication
+
+#### Using Client ID and Client Secret
+
+Export the required environment variables:
 
 ```bash
 export FALCON_CLIENT_ID="XXXXXXX"
 export FALCON_CLIENT_SECRET="YYYYYYYYY"
 ```
 
+#### Using AWS SSM
+
 The installer is AWS SSM aware, if `FALCON_CLIENT_ID` and `FALCON_CLIENT_SECRET` are not provided AND the script is running on an AWS instance, the script will try to get API credentials from the SSM store of the region.
+
+### Additional Configuration
 
 Optional environment variables that can be exported:
 
@@ -51,6 +59,8 @@ FALCON_BILLING                    (default: default) possible values: [default|m
 FALCON_BACKEND                    (default: auto)    possible values: [auto|bpf|kernel]
 FALCON_TRACE                      (default: none)    possible values: [none|err|warn|info|debug]
 ALLOW_LEGACY_CURL                 (default: false)
+GET_ACCESS_TOKEN                  (default: false)   possible values: [true|false]
+FALCON_REMOVE_HOST                (default: true)
 ```
 
 **Run the script**:

--- a/bash/install/falcon-linux-install.sh
+++ b/bash/install/falcon-linux-install.sh
@@ -8,10 +8,12 @@ CrowdStrike API credentials are needed to download Falcon sensor. The script rec
 
     - FALCON_CLIENT_ID
     - FALCON_CLIENT_SECRET
+    or 
+    - FALCON_ACCESS_TOKEN               (default: unset)
+    - FALCON_CLOUD                      (default: auto)
 
 Optional:
     - FALCON_CID                        (default: auto)
-    - FALCON_CLOUD                      (default: auto)
     - FALCON_SENSOR_VERSION_DECREMENT   (default: 0 [latest])
     - FALCON_PROVISIONING_TOKEN         (default: unset)
     - FALCON_SENSOR_UPDATE_POLICY_NAME  (default: unset)
@@ -25,6 +27,7 @@ Optional:
     - FALCON_UNINSTALL                  (default: false)
     - FALCON_INSTALL_ONLY               (default: false)
     - ALLOW_LEGACY_CURL                 (default: false)
+    - GET_ACCESS_TOKEN                  (default: false)   possible values: [true|false]
 EOF
 }
 
@@ -33,6 +36,12 @@ main() {
         print_usage
         exit 1
     fi
+
+    if [ "$GET_ACCESS_TOKEN" = "true" ]; then
+        echo "$cs_falcon_oauth_token"
+        exit 1
+    fi
+
     echo -n 'Check if Falcon Sensor is running ... '
     cs_sensor_is_running
     echo '[ Not present ]'
@@ -621,25 +630,31 @@ aws_instance=$(
     fi
 )
 
-cs_falcon_client_id=$(
-    if [ -n "$FALCON_CLIENT_ID" ]; then
-        echo "$FALCON_CLIENT_ID"
-    elif [ -n "$aws_instance" ]; then
-        aws_ssm_parameter "FALCON_CLIENT_ID" | json_value Value 1
-    else
-        die "Missing FALCON_CLIENT_ID environment variable. Please provide your OAuth2 API Client ID for authentication with CrowdStrike Falcon platform. Establishing and retrieving OAuth2 API credentials can be performed at https://falcon.crowdstrike.com/support/api-clients-and-keys."
-    fi
-)
+if [ -z "$FALCON_ACCESS_TOKEN" ]; then
+    cs_falcon_client_id=$(
+        if [ -n "$FALCON_CLIENT_ID" ]; then
+            echo "$FALCON_CLIENT_ID"
+        elif [ -n "$aws_instance" ]; then
+            aws_ssm_parameter "FALCON_CLIENT_ID" | json_value Value 1
+        else
+            die "Missing FALCON_CLIENT_ID environment variable. Please provide your OAuth2 API Client ID for authentication with CrowdStrike Falcon platform. Establishing and retrieving OAuth2 API credentials can be performed at https://falcon.crowdstrike.com/support/api-clients-and-keys."
+        fi
+    )
 
-cs_falcon_client_secret=$(
-    if [ -n "$FALCON_CLIENT_SECRET" ]; then
-        echo "$FALCON_CLIENT_SECRET"
-    elif [ -n "$aws_instance" ]; then
-        aws_ssm_parameter "FALCON_CLIENT_SECRET" | json_value Value 1
-    else
-        die "Missing FALCON_CLIENT_SECRET environment variable. Please provide your OAuth2 API Client Secret for authentication with CrowdStrike Falcon platform. Establishing and retrieving OAuth2 API credentials can be performed at https://falcon.crowdstrike.com/support/api-clients-and-keys."
+    cs_falcon_client_secret=$(
+        if [ -n "$FALCON_CLIENT_SECRET" ]; then
+            echo "$FALCON_CLIENT_SECRET"
+        elif [ -n "$aws_instance" ]; then
+            aws_ssm_parameter "FALCON_CLIENT_SECRET" | json_value Value 1
+        else
+            die "Missing FALCON_CLIENT_SECRET environment variable. Please provide your OAuth2 API Client Secret for authentication with CrowdStrike Falcon platform. Establishing and retrieving OAuth2 API credentials can be performed at https://falcon.crowdstrike.com/support/api-clients-and-keys."
+        fi
+    )
+else
+    if [ -z "$FALCON_CLOUD" ]; then
+        die "If setting the FALCON_ACCESS_TOKEN manually, you must also specify the FALCON_CLOUD"
     fi
-)
+fi
 
 cs_falcon_token=$(
     if [ -n "$FALCON_PROVISIONING_TOKEN" ]; then
@@ -701,18 +716,22 @@ proxy=$(
 )
 
 cs_falcon_oauth_token=$(
-    token_result=$(echo "client_id=$cs_falcon_client_id&client_secret=$cs_falcon_client_secret" |
-        curl -X POST -s -x "$proxy" -L "https://$(cs_cloud)/oauth2/token" \
-            -H 'Content-Type: application/x-www-form-urlencoded; charset=utf-8' \
-            -H 'User-Agent: crowdstrike-falcon-scripts/1.3.3' \
-            --dump-header "${response_headers}" \
-            --data @-)
+    if [ -n "$FALCON_ACCESS_TOKEN" ]; then
+        token=$FALCON_ACCESS_TOKEN
+    else
+        token_result=$(echo "client_id=$cs_falcon_client_id&client_secret=$cs_falcon_client_secret" |
+            curl -X POST -s -x "$proxy" -L "https://$(cs_cloud)/oauth2/token" \
+                -H 'Content-Type: application/x-www-form-urlencoded; charset=utf-8' \
+                -H 'User-Agent: crowdstrike-falcon-scripts/1.3.3' \
+                --dump-header "${response_headers}" \
+                --data @-)
 
-    handle_curl_error $?
+        handle_curl_error $?
 
-    token=$(echo "$token_result" | json_value "access_token" | sed 's/ *$//g' | sed 's/^ *//g')
-    if [ -z "$token" ]; then
-        die "Unable to obtain CrowdStrike Falcon OAuth Token. Response was $token_result"
+        token=$(echo "$token_result" | json_value "access_token" | sed 's/ *$//g' | sed 's/^ *//g')
+        if [ -z "$token" ]; then
+            die "Unable to obtain CrowdStrike Falcon OAuth Token. Response was $token_result"
+        fi
     fi
     echo "$token"
 )
@@ -726,7 +745,9 @@ if [ -z "${FALCON_CLOUD}" ]; then
     fi
     cs_falcon_cloud="${region_hint}"
 else
-    if [ "x${FALCON_CLOUD}" != "x${region_hint}" ]; then
+    if [ -n "$FALCON_ACCESS_TOKEN" ]; then
+        :
+    elif [ "x${FALCON_CLOUD}" != "x${region_hint}" ]; then
         echo "WARNING: FALCON_CLOUD='${FALCON_CLOUD}' environment variable specified while credentials only exists in '${region_hint}'" >&2
     fi
 fi

--- a/bash/install/falcon-linux-uninstall.sh
+++ b/bash/install/falcon-linux-uninstall.sh
@@ -4,6 +4,21 @@ print_usage() {
     cat <<EOF
 This script removes the CrowdStrike Falcon Sensor for Linux from the operating system.
 
+Crowdstrike API credentials are needed to remove host from the Falcon console
+
+    - FALCON_CLIENT_ID
+    - FALCON_CLIENT_SECRET
+    or 
+    - FALCON_ACCESS_TOKEN               (default: unset)
+    - FALCON_CLOUD                      (default: auto)
+
+
+Optional:
+    - GET_ACCESS_TOKEN                  (default: false)   possible values: [true|false
+    - FALCON_APH                        (default: unset)
+    - FALCON_APP                        (default: unset)
+    - FALCON_REMOVE_HOST                (default: true)
+
 EOF
 }
 
@@ -15,6 +30,11 @@ main() {
     echo -n 'Removing Falcon Sensor  ... '
     cs_sensor_remove
     echo '[ Ok ]'
+    if [ -z "$FALCON_REMOVE_HOST" ] || [ "${FALCON_REMOVE_HOST}" = "true" ]; then
+        echo -n 'Removing host from console ... '
+        cs_remove_host_from_console
+        echo '[ Ok ] '
+    fi
     echo 'Falcon Sensor removed successfully.'
 }
 
@@ -37,5 +57,176 @@ cs_sensor_remove() {
 
     remove_package "falcon-sensor"
 }
+
+cs_remove_host_from_console() {
+    if [ "$aid" = "" ]; then
+        echo 'unable to find aid'
+    else
+        curl_command -X "POST" "https://$(cs_cloud)/devices/entities/devices-actions/v2?action_name=hide_host" -d "{    \"ids\": [    \"$aid\"  ]}" -H 'Content-Type: application/json'
+        handle_curl_error $?
+    fi
+}
+
+cs_cloud() {
+    case "${cs_falcon_cloud}" in
+    us-1) echo "api.crowdstrike.com" ;;
+    us-2) echo "api.us-2.crowdstrike.com" ;;
+    eu-1) echo "api.eu-1.crowdstrike.com" ;;
+    us-gov-1) echo "api.laggar.gcw.crowdstrike.com" ;;
+    *) die "Unrecognized Falcon Cloud: ${cs_falcon_cloud}" ;;
+    esac
+}
+
+if ! test -f /opt/CrowdStrike/falconctl; then
+    echo "Falcon sensor is not installed."
+    exit 1
+fi
+
+old_curl=$(
+    if ! command -v curl >/dev/null 2>&1; then
+        die "The 'curl' command is missing. Please install it before continuing. Aborting..."
+    fi
+
+    version=$(curl --version | head -n 1 | awk '{ print $2 }')
+    minimum="7.55"
+
+    # Check if the version is less than the minimum
+    if printf "%s\n" "$version" "$minimum" | sort -V -C; then
+        echo 0
+    else
+        echo 1
+    fi
+)
+
+curl_command() {
+    # Dash does not support arrays, so we have to pass the args as separate arguments
+    set -- "$@"
+
+    if [ "$old_curl" -eq 0 ]; then
+        curl -s -x "$proxy" -L -H "Authorization: Bearer ${cs_falcon_oauth_token}" "$@"
+    else
+        echo "Authorization: Bearer ${cs_falcon_oauth_token}" | curl -s -x "$proxy" -L -H @- "$@"
+    fi
+}
+
+handle_curl_error() {
+    if [ "$1" = "28" ]; then
+        err_msg="Operation timed out (exit code 28)."
+        if [ -n "$proxy" ]; then
+            err_msg="$err_msg A proxy was used to communicate ($proxy). Please check your proxy settings."
+        fi
+        die "$err_msg"
+    fi
+
+    if [ "$1" = "5" ]; then
+        err_msg="Couldn't resolve proxy (exit code 5). The address ($proxy) of the given proxy host could not be resolved. Please check your proxy settings."
+        die "$err_msg"
+    fi
+
+    if [ "$1" = "7" ]; then
+        err_msg="Failed to connect to host (exit code 7). Host found, but unable to open connection with host."
+        if [ -n "$proxy" ]; then
+            err_msg="$err_msg A proxy was used to communicate ($proxy). Please check your proxy settings."
+        fi
+        die "$err_msg"
+    fi
+}
+
+json_value() {
+    KEY=$1
+    num=$2
+    awk -F"[,:}]" '{for(i=1;i<=NF;i++){if($i~/'"$KEY"'\042/){print $(i+1)}}}' | tr -d '"' | sed -n "${num}p"
+}
+
+die() {
+    echo "Fatal error: $*" >&2
+    exit 1
+}
+
+cs_falcon_cloud=$(
+    if [ -n "$FALCON_CLOUD" ]; then
+        echo "$FALCON_CLOUD"
+    else
+        # Auto-discovery is using us-1 initially
+        echo "us-1"
+    fi
+)
+
+response_headers=$(mktemp)
+
+# shellcheck disable=SC2001
+proxy=$(
+    proxy=""
+    if [ -n "$FALCON_APH" ]; then
+        proxy="$(echo "$FALCON_APH" | sed "s|http.*://||")"
+
+        if [ -n "$FALCON_APP" ]; then
+            proxy="$proxy:$FALCON_APP"
+        fi
+    fi
+
+    if [ -n "$proxy" ]; then
+        # Remove redundant quotes
+        proxy="$(echo "$proxy" | sed "s/[\'\"]//g")"
+        proxy="http://$proxy"
+    fi
+    echo "$proxy"
+)
+
+cs_falcon_client_id=$(
+    if [ -n "$FALCON_CLIENT_ID" ]; then
+        echo "$FALCON_CLIENT_ID"
+    elif [ -n "$aws_instance" ]; then
+        aws_ssm_parameter "FALCON_CLIENT_ID" | json_value Value 1
+    else
+        die "Missing FALCON_CLIENT_ID environment variable. Please provide your OAuth2 API Client ID for authentication with CrowdStrike Falcon platform. Establishing and retrieving OAuth2 API credentials can be performed at https://falcon.crowdstrike.com/support/api-clients-and-keys."
+    fi
+)
+
+cs_falcon_client_secret=$(
+    if [ -n "$FALCON_CLIENT_SECRET" ]; then
+        echo "$FALCON_CLIENT_SECRET"
+    elif [ -n "$aws_instance" ]; then
+        aws_ssm_parameter "FALCON_CLIENT_SECRET" | json_value Value 1
+    else
+        die "Missing FALCON_CLIENT_SECRET environment variable. Please provide your OAuth2 API Client Secret for authentication with CrowdStrike Falcon platform. Establishing and retrieving OAuth2 API credentials can be performed at https://falcon.crowdstrike.com/support/api-clients-and-keys."
+    fi
+)
+
+cs_falcon_oauth_token=$(
+    token_result=$(echo "client_id=$cs_falcon_client_id&client_secret=$cs_falcon_client_secret" |
+        curl -X POST -s -x "$proxy" -L "https://$(cs_cloud)/oauth2/token" \
+            -H 'Content-Type: application/x-www-form-urlencoded; charset=utf-8' \
+            -H 'User-Agent: crowdstrike-falcon-scripts/1.3.3' \
+            --dump-header "${response_headers}" \
+            --data @-)
+
+    handle_curl_error $?
+
+    token=$(echo "$token_result" | json_value "access_token" | sed 's/ *$//g' | sed 's/^ *//g')
+    if [ -z "$token" ]; then
+        die "Unable to obtain CrowdStrike Falcon OAuth Token. Response was $token_result"
+    fi
+
+    echo "$token"
+)
+
+region_hint=$(grep -i ^x-cs-region: "$response_headers" | head -n 1 | tr '[:upper:]' '[:lower:]' | tr -d '\r' | sed 's/^x-cs-region: //g')
+rm "${response_headers}"
+
+if [ -z "${FALCON_CLOUD}" ]; then
+    if [ -z "${region_hint}" ]; then
+        die "Unable to obtain region hint from CrowdStrike Falcon OAuth API, Please provide FALCON_CLOUD environment variable as an override."
+    fi
+    cs_falcon_cloud="${region_hint}"
+else
+    if [ -n "$FALCON_ACCESS_TOKEN" ]; then
+        :
+    elif [ "x${FALCON_CLOUD}" != "x${region_hint}" ]; then
+        echo "WARNING: FALCON_CLOUD='${FALCON_CLOUD}' environment variable specified while credentials only exists in '${region_hint}'" >&2
+    fi
+fi
+
+aid="$(/opt/CrowdStrike/falconctl -g --aid | cut -c 6- | rev | cut -c 3- | rev)"
 
 main "$@"

--- a/bash/install/falcon-linux-uninstall.sh
+++ b/bash/install/falcon-linux-uninstall.sh
@@ -8,10 +8,6 @@ Crowdstrike API credentials are needed to remove host from the Falcon console
 
     - FALCON_CLIENT_ID
     - FALCON_CLIENT_SECRET
-    or 
-    - FALCON_ACCESS_TOKEN               (default: unset)
-    - FALCON_CLOUD                      (default: auto)
-
 
 Optional:
     - GET_ACCESS_TOKEN                  (default: false)   possible values: [true|false

--- a/bash/install/falcon-linux-uninstall.sh
+++ b/bash/install/falcon-linux-uninstall.sh
@@ -65,11 +65,11 @@ cs_remove_host_from_console() {
 
 cs_cloud() {
     case "${cs_falcon_cloud}" in
-    us-1) echo "api.crowdstrike.com" ;;
-    us-2) echo "api.us-2.crowdstrike.com" ;;
-    eu-1) echo "api.eu-1.crowdstrike.com" ;;
-    us-gov-1) echo "api.laggar.gcw.crowdstrike.com" ;;
-    *) die "Unrecognized Falcon Cloud: ${cs_falcon_cloud}" ;;
+        us-1) echo "api.crowdstrike.com" ;;
+        us-2) echo "api.us-2.crowdstrike.com" ;;
+        eu-1) echo "api.eu-1.crowdstrike.com" ;;
+        us-gov-1) echo "api.laggar.gcw.crowdstrike.com" ;;
+        *) die "Unrecognized Falcon Cloud: ${cs_falcon_cloud}" ;;
     esac
 }
 

--- a/powershell/install/README.md
+++ b/powershell/install/README.md
@@ -17,6 +17,33 @@ Ensure the following API scopes are enabled:
 
 ## Configuration
 
+### Setting up Authentication
+
+#### Using Client ID and Client Secret
+
+Provide the required parameters:
+
+```powershell
+.\falcon_windows_install.ps1 -FalconClientId <string> -FalconClientSecret <string> 
+```
+
+#### Using an Access Token
+
+You can also specify a Falcon access token if doing a batch install across multiple machines to prevent the need to call the token endpoint multiple times. If using an access token to authenticate, you ***MUST*** also provide `FALCON_CLOUD`:
+
+```powershell
+.\falcon_windows_install.ps1 -FalconCloud us-2 -FalconAccessToken <string>
+```
+
+> [!NOTE]
+> If you need to retrieve an access token, run the script with the `GET_ACCESS_TOKEN` parameter set to `true`. The Falcon sensor will NOT be installed while this parameteris provided.
+>
+> ```powershell
+> .\falcon_windows_install.ps1 -FalconClientId <string> -FalconClientSecret <string> -GetAccessToken True
+> ```
+>
+> The script will output the access token to the console.
+
 ### Install
 
 Uses the CrowdStrike Falcon APIs to check the sensor version assigned to a ***Windows Sensor Update policy***,

--- a/powershell/install/falcon_windows_install.ps1
+++ b/powershell/install/falcon_windows_install.ps1
@@ -48,6 +48,10 @@ By default, the Falcon sensor for Windows automatically attempts to use any avai
 This parameter forces the sensor to skip those attempts and ignore any proxy configuration, including Windows Proxy Auto Detection.
 .PARAMETER Verbose
 Enable verbose logging
+.PARAMETER GetAccessToken
+Flag to return API credential access token
+.PARAMETER FalconAccessToken
+Manually set Falcon access token. Used to reduce number of requests to the token endpoint when performing batch installs.
 .EXAMPLE
 PS>.\falcon_windows_install.ps1 -FalconClientId <string> -FalconClientSecret <string>
 
@@ -115,7 +119,13 @@ param(
     [int] $ProxyPort,
 
     [Parameter(Position = 16)]
-    [switch] $ProxyDisable
+    [switch] $ProxyDisable,
+
+    [Parameter(Position = 17)]
+    [bool] $GetAccessToken = $false,
+
+    [Parameter(Position = 18)]
+    [string] $FalconAccessToken
 )
 begin {
     if ($PSVersionTable.PSVersion -lt '3.0')
@@ -181,56 +191,66 @@ begin {
     function Invoke-FalconAuth([hashtable] $WebRequestParams, [string] $BaseUrl, [hashtable] $Body, [string] $FalconCloud) {
         $Headers = @{'Accept' = 'application/json'; 'Content-Type' = 'application/x-www-form-urlencoded'; 'charset' = 'utf-8' }
         $Headers.Add('User-Agent', 'crowdstrike-falcon-scripts/1.3.3')
-        try {
-            $response = Invoke-WebRequest @WebRequestParams -Uri "$($BaseUrl)/oauth2/token" -UseBasicParsing -Method 'POST' -Headers $Headers -Body $Body
-            $content = ConvertFrom-Json -InputObject $response.Content
-            Write-VerboseLog -VerboseInput $content -PreMessage 'Invoke-FalconAuth - $content:'
-
-            if ([string]::IsNullOrEmpty($content.access_token)) {
-                $message = 'Unable to authenticate to the CrowdStrike Falcon API. Please check your credentials and try again.'
-                throw $message
-            }
-
-            $Headers.Add('Authorization', "bearer $($content.access_token)")
+        if ($FalconAccessToken){
+            $Headers.Add('Authorization', "bearer $($FalconAccessToken)")
         }
-        catch {
-            # Handle redirects
-            Write-Verbose "Invoke-FalconAuth - CAUGHT EXCEPTION - `$_.Exception.Message`r`n$($_.Exception.Message)"
-            $response = $_.Exception.Response
-
-            if (!$response) {
-                $message = "Unhandled error occurred while authenticating to the CrowdStrike Falcon API. Error: $($_.Exception.Message)"
-                Write-FalconLog -Source 'Invoke-FalconAuth' -Message $message
-                throw $message
-            }
-
-            if ($response.StatusCode -in @(301, 302, 303, 307, 308)) {
-                # If autodiscover is enabled, try to get the correct cloud
-                if ($FalconCloud -eq 'autodiscover') {
-                    if ($response.Headers.Contains('X-Cs-Region')) {
-                        $region = $response.Headers.GetValues('X-Cs-Region')[0]
-                        Write-Verbose "Received a redirect to $region. Setting FalconCloud to $region"
-                    }
-                    else {
-                        $message = 'Received a redirect but no X-Cs-Region header was provided. Unable to autodiscover the FalconCloud. Please set FalconCloud to the correct region.'
-                        Write-FalconLog -Source 'Invoke-FalconAuth' -Message $message
-                        throw $message
-                    }
-
-                    $BaseUrl = Get-FalconCloud($region)
-                    $BaseUrl, $Headers = Invoke-FalconAuth -WebRequestParams $WebRequestParams -BaseUrl $BaseUrl -Body $Body -FalconCloud $FalconCloud
-
+        else{
+            try {
+                $response = Invoke-WebRequest @WebRequestParams -Uri "$($BaseUrl)/oauth2/token" -UseBasicParsing -Method 'POST' -Headers $Headers -Body $Body
+                $content = ConvertFrom-Json -InputObject $response.Content
+                Write-VerboseLog -VerboseInput $content -PreMessage 'Invoke-FalconAuth - $content:'
+    
+                if ([string]::IsNullOrEmpty($content.access_token)) {
+                    $message = 'Unable to authenticate to the CrowdStrike Falcon API. Please check your credentials and try again.'
+                    throw $message
                 }
-                else {
-                    $message = "Received a redirect. Please set FalconCloud to 'autodiscover' or the correct region."
+    
+                if ($GetAccessToken -eq $true){
+                    Write-Output $content.access_token | out-host
+                    exit
+                }
+
+                $Headers.Add('Authorization', "bearer $($content.access_token)")
+            }
+            catch {
+                # Handle redirects
+                Write-Verbose "Invoke-FalconAuth - CAUGHT EXCEPTION - `$_.Exception.Message`r`n$($_.Exception.Message)"
+                $response = $_.Exception.Response
+
+                if (!$response) {
+                    $message = "Unhandled error occurred while authenticating to the CrowdStrike Falcon API. Error: $($_.Exception.Message)"
                     Write-FalconLog -Source 'Invoke-FalconAuth' -Message $message
                     throw $message
                 }
-            }
-            else {
-                $message = "Received a $($response.StatusCode) response from $($BaseUrl)oauth2/token. Please check your credentials and try again. Error: $($response.StatusDescription)"
-                Write-FalconLog -Source 'Invoke-FalconAuth' -Message $message
-                throw $message
+
+                if ($response.StatusCode -in @(301, 302, 303, 307, 308)) {
+                    # If autodiscover is enabled, try to get the correct cloud
+                    if ($FalconCloud -eq 'autodiscover') {
+                        if ($response.Headers.Contains('X-Cs-Region')) {
+                            $region = $response.Headers.GetValues('X-Cs-Region')[0]
+                            Write-Verbose "Received a redirect to $region. Setting FalconCloud to $region"
+                        }
+                        else {
+                            $message = 'Received a redirect but no X-Cs-Region header was provided. Unable to autodiscover the FalconCloud. Please set FalconCloud to the correct region.'
+                            Write-FalconLog -Source 'Invoke-FalconAuth' -Message $message
+                            throw $message
+                        }
+
+                        $BaseUrl = Get-FalconCloud($region)
+                        $BaseUrl, $Headers = Invoke-FalconAuth -WebRequestParams $WebRequestParams -BaseUrl $BaseUrl -Body $Body -FalconCloud $FalconCloud
+
+                    }
+                    else {
+                        $message = "Received a redirect. Please set FalconCloud to 'autodiscover' or the correct region."
+                        Write-FalconLog -Source 'Invoke-FalconAuth' -Message $message
+                        throw $message
+                    }
+                }
+                else {
+                    $message = "Received a $($response.StatusCode) response from $($BaseUrl)oauth2/token. Please check your credentials and try again. Error: $($response.StatusDescription)"
+                    Write-FalconLog -Source 'Invoke-FalconAuth' -Message $message
+                    throw $message
+                }
             }
         }
 
@@ -417,7 +437,7 @@ process {
     }
 
     # Configure OAuth2 authentication
-    if ($credsProvided) {
+    if ($credsProvided -or $FalconAccessToken) {
         $BaseUrl = Get-FalconCloud $FalconCloud
 
         $Body = @{}

--- a/powershell/install/falcon_windows_install.ps1
+++ b/powershell/install/falcon_windows_install.ps1
@@ -199,12 +199,12 @@ begin {
                 $response = Invoke-WebRequest @WebRequestParams -Uri "$($BaseUrl)/oauth2/token" -UseBasicParsing -Method 'POST' -Headers $Headers -Body $Body
                 $content = ConvertFrom-Json -InputObject $response.Content
                 Write-VerboseLog -VerboseInput $content -PreMessage 'Invoke-FalconAuth - $content:'
-    
+
                 if ([string]::IsNullOrEmpty($content.access_token)) {
                     $message = 'Unable to authenticate to the CrowdStrike Falcon API. Please check your credentials and try again.'
                     throw $message
                 }
-    
+
                 if ($GetAccessToken -eq $true){
                     Write-Output $content.access_token | out-host
                     exit

--- a/powershell/install/falcon_windows_uninstall.ps1
+++ b/powershell/install/falcon_windows_uninstall.ps1
@@ -194,7 +194,7 @@ begin {
                     Write-Output $content.access_token | out-host
                     exit
                 }
-    
+
                 $Headers.Add('Authorization', "bearer $($content.access_token)")
             }
             catch {

--- a/powershell/install/falcon_windows_uninstall.ps1
+++ b/powershell/install/falcon_windows_uninstall.ps1
@@ -40,6 +40,10 @@ The proxy host for the sensor to use when communicating with CrowdStrike [defaul
 The proxy port for the sensor to use when communicating with CrowdStrike [default: $null]
 .PARAMETER Verbose
 Enable verbose logging
+.PARAMETER GetAccessToken
+Flag to return API credential access token
+.PARAMETER FalconAccessToken
+Manually set Falcon access token. Used to reduce number of requests to the token endpoint when performing batch installs.
 .EXAMPLE
 PS>.\falcon_windows_uninstall.ps1 -MaintenanceToken <string>
 
@@ -95,9 +99,24 @@ param(
     [string] $ProxyHost,
 
     [Parameter(Position = 13)]
-    [int] $ProxyPort
+    [int] $ProxyPort,
+
+    [Parameter(Position = 14)]
+    [bool] $GetAccessToken = $false,
+
+    [Parameter(Position = 15)]
+    [string] $FalconAccessToken
 )
 begin {
+
+    if ($FalconAccessToken){
+        if ($FalconCloud -eq "autodiscover"){
+            $Message = 'Unable to auto discover Falcon region using access token, please provide FalconCloud'
+            throw $Message
+        }
+        
+    }
+
     $ScriptName = $MyInvocation.MyCommand.Name
     $ScriptPath = if (!$PSScriptRoot) {
         Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
@@ -157,56 +176,66 @@ begin {
     function Invoke-FalconAuth([hashtable] $WebRequestParams, [string] $BaseUrl, [hashtable] $Body, [string] $FalconCloud) {
         $Headers = @{'Accept' = 'application/json'; 'Content-Type' = 'application/x-www-form-urlencoded'; 'charset' = 'utf-8' }
         $Headers.Add('User-Agent', 'crowdstrike-falcon-scripts/1.3.3')
-        try {
-            $response = Invoke-WebRequest @WebRequestParams -Uri "$($BaseUrl)/oauth2/token" -UseBasicParsing -Method 'POST' -Headers $Headers -Body $Body
-            $content = ConvertFrom-Json -InputObject $response.Content
-            Write-VerboseLog -VerboseInput $content -PreMessage 'Invoke-FalconAuth - $content:'
-
-            if ([string]::IsNullOrEmpty($content.access_token)) {
-                $Message = 'Unable to authenticate to the CrowdStrike Falcon API. Please check your credentials and try again.'
-                throw $Message
-            }
-
-            $Headers.Add('Authorization', "bearer $($content.access_token)")
+        if ($FalconAccessToken){
+            $Headers.Add('Authorization', "bearer $($FalconAccessToken)")
         }
-        catch {
-            # Handle redirects
-            Write-Verbose "Invoke-FalconAuth - CAUGHT EXCEPTION - `$_.Exception.Message`r`n$($_.Exception.Message)"
-            $response = $_.Exception.Response
+        else{
+            try {
+                $response = Invoke-WebRequest @WebRequestParams -Uri "$($BaseUrl)/oauth2/token" -UseBasicParsing -Method 'POST' -Headers $Headers -Body $Body
+                $content = ConvertFrom-Json -InputObject $response.Content
+                Write-VerboseLog -VerboseInput $content -PreMessage 'Invoke-FalconAuth - $content:'
 
-            if (!$response) {
-                $Message = "Unhandled error occurred while authenticating to the CrowdStrike Falcon API. Error: $($_.Exception.Message)"
-                Write-FalconLog -Source 'Invoke-FalconAuth' -Message $Message
-                throw $Message
-            }
-
-            if ($response.StatusCode -in @(301, 302, 303, 307, 308)) {
-                # If autodiscover is enabled, try to get the correct cloud
-                if ($FalconCloud -eq 'autodiscover') {
-                    if ($response.Headers.Contains('X-Cs-Region')) {
-                        $region = $response.Headers.GetValues('X-Cs-Region')[0]
-                        Write-Verbose "Received a redirect to $region. Setting FalconCloud to $region"
-                    }
-                    else {
-                        $Message = 'Received a redirect but no X-Cs-Region header was provided. Unable to autodiscover the FalconCloud. Please set FalconCloud to the correct region.'
-                        Write-FalconLog -Source 'Invoke-FalconAuth' -Message $Message
-                        throw $Message
-                    }
-
-                    $BaseUrl = Get-FalconCloud($region)
-                    $BaseUrl, $Headers = Invoke-FalconAuth -WebRequestParams $WebRequestParams -BaseUrl $BaseUrl -Body $Body -FalconCloud $FalconCloud
-
+                if ([string]::IsNullOrEmpty($content.access_token)) {
+                    $Message = 'Unable to authenticate to the CrowdStrike Falcon API. Please check your credentials and try again.'
+                    throw $Message
                 }
-                else {
-                    $Message = "Received a redirect. Please set FalconCloud to 'autodiscover' or the correct region."
+
+                if ($GetAccessToken -eq $true){
+                    Write-Output $content.access_token | out-host
+                    exit
+                }
+    
+                $Headers.Add('Authorization', "bearer $($content.access_token)")
+            }
+            catch {
+                # Handle redirects
+                Write-Verbose "Invoke-FalconAuth - CAUGHT EXCEPTION - `$_.Exception.Message`r`n$($_.Exception.Message)"
+                $response = $_.Exception.Response
+
+                if (!$response) {
+                    $Message = "Unhandled error occurred while authenticating to the CrowdStrike Falcon API. Error: $($_.Exception.Message)"
                     Write-FalconLog -Source 'Invoke-FalconAuth' -Message $Message
                     throw $Message
                 }
-            }
-            else {
-                $Message = "Received a $($response.StatusCode) response from $($BaseUrl)oauth2/token. Please check your credentials and try again. Error: $($response.StatusDescription)"
-                Write-FalconLog -Source 'Invoke-FalconAuth' -Message $Message
-                throw $Message
+
+                if ($response.StatusCode -in @(301, 302, 303, 307, 308)) {
+                    # If autodiscover is enabled, try to get the correct cloud
+                    if ($FalconCloud -eq 'autodiscover') {
+                        if ($response.Headers.Contains('X-Cs-Region')) {
+                            $region = $response.Headers.GetValues('X-Cs-Region')[0]
+                            Write-Verbose "Received a redirect to $region. Setting FalconCloud to $region"
+                        }
+                        else {
+                            $Message = 'Received a redirect but no X-Cs-Region header was provided. Unable to autodiscover the FalconCloud. Please set FalconCloud to the correct region.'
+                            Write-FalconLog -Source 'Invoke-FalconAuth' -Message $Message
+                            throw $Message
+                        }
+
+                        $BaseUrl = Get-FalconCloud($region)
+                        $BaseUrl, $Headers = Invoke-FalconAuth -WebRequestParams $WebRequestParams -BaseUrl $BaseUrl -Body $Body -FalconCloud $FalconCloud
+
+                    }
+                    else {
+                        $Message = "Received a redirect. Please set FalconCloud to 'autodiscover' or the correct region."
+                        Write-FalconLog -Source 'Invoke-FalconAuth' -Message $Message
+                        throw $Message
+                    }
+                }
+                else {
+                    $Message = "Received a $($response.StatusCode) response from $($BaseUrl)oauth2/token. Please check your credentials and try again. Error: $($response.StatusDescription)"
+                    Write-FalconLog -Source 'Invoke-FalconAuth' -Message $Message
+                    throw $Message
+                }
             }
         }
 
@@ -374,9 +403,9 @@ process {
 
     # Verify creds are provided if using the API
     $credsProvided = Test-FalconCredential $FalconClientId $FalconClientSecret
-    if (!$credsProvided) {
+    if (!$credsProvided -or !$FalconAccessToken) {
         if ($RemoveHost) {
-            $Message = 'Unable to remove host without credentials, please provide FalconClientId and FalconClientSecret'
+            $Message = 'Unable to remove host without credentials, please provide FalconClientId and FalconClientSecret or FalconAccessToken'
             throw $Message
         }
     }
@@ -422,7 +451,7 @@ process {
         $WebRequestParams.Add('Proxy', $proxy)
     }
 
-    if ($credsProvided) {
+    if ($credsProvided -or $FalconAccessToken) {
         $BaseUrl = Get-FalconCloud $FalconCloud
 
         $Body = @{}
@@ -449,7 +478,10 @@ process {
         $UninstallParams += " MAINTENANCE_TOKEN=$MaintenanceToken"
     }
     else {
+
         if ($aid) {
+
+
             # Assume user wants to use API to retrieve token
             # Build request body for retrieving maintenance token
             Write-FalconLog 'GetToken' 'Retrieving maintenance token from the CrowdStrike Falcon API.'

--- a/powershell/install/falcon_windows_uninstall.ps1
+++ b/powershell/install/falcon_windows_uninstall.ps1
@@ -114,7 +114,7 @@ begin {
             $Message = 'Unable to auto discover Falcon region using access token, please provide FalconCloud'
             throw $Message
         }
-        
+
     }
 
     $ScriptName = $MyInvocation.MyCommand.Name


### PR DESCRIPTION
This PR adds functionality to use a pre-generated auth token to authenticate with the Crowdstrike API when deploying to multiple machines.

#211 