### PR TITLE
falcon-linux-install.sh: fix ordering of restart type

### DIFF
--- a/bash/install/falcon-linux-install.sh
+++ b/bash/install/falcon-linux-install.sh
@@ -110,10 +110,10 @@ cs_sensor_is_running() {
 }
 
 cs_sensor_restart() {
-    if type service >/dev/null 2>&1; then
-        service falcon-sensor restart
-    elif type systemctl >/dev/null 2>&1; then
+    if type systemctl >/dev/null 2>&1; then
         systemctl restart falcon-sensor
+    elif type service >/dev/null 2>&1; then
+        service falcon-sensor restart
     else
         die "Could not restart falcon sensor"
     fi


### PR DESCRIPTION
On most (or all) platforms that use systemd, a SysVinit compatibility script is provided at `/usr/sbin/service`. When one runs /usr/sbin/service it works but issues a warning like "redirecting to systemctl".

The falcon-linux-install.sh script, tests for `service` first, and then `systemctl`. Because of the compatibiliity script, the `service` conditional always matches, even on modern systemd systems. Thus systemd systems always use the compatibility script and always issue the "redirecting to systemctl" message. It is more ideal to just use systemctl on a systemd system.

This patch reverses the tests, checking `systemctl` first, which is obviously the most common case and then checking for `service` second. On systemd-based systems this will result in the best behaviour, using systemctl and on older sysVinit systems the behaviour is unchanged.
