### PR TITLE
ci: update shfmt to allow reviewdog access to update pr

### DIFF
--- a/.github/workflows/shell_format.yml
+++ b/.github/workflows/shell_format.yml
@@ -1,9 +1,4 @@
 on:
-  push:
-    paths:
-      - 'bash/**'
-      - '.github/workflows/shell_format.yml'
-
   pull_request:
     paths:
       - 'bash/**'
@@ -12,6 +7,8 @@ on:
 jobs:
   shfmt:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - uses: actions/checkout@v4
     - name: Run shfmt with reviewdog


### PR DESCRIPTION
Previous runs of this would cause reviewdog to fail since it didn't have permissions to update the PR to show the issues found.