### PR TITLE
fix(windows_install): add better error handling around exitcode

### DIFF
--- a/powershell/install/falcon_windows_install.ps1
+++ b/powershell/install/falcon_windows_install.ps1
@@ -41,7 +41,7 @@ Delete script when complete [default: $false]
 .PARAMETER ProvToken
 Provisioning token to use for sensor installation [default: $null]
 .PARAMETER ProvWaitTime
-Time to wait, in seconds, for sensor to provision [default: 1200]
+Time to wait, in milliseconds, for sensor to provision [default: 1200000]
 .PARAMETER Tags
 A comma-separated list of tags to apply to the host after sensor installation [default: $null]
 .PARAMETER ProxyHost
@@ -105,7 +105,7 @@ param(
     [string] $ProvToken,
 
     [Parameter(Position = 11)]
-    [int] $ProvWaitTime = 1200,
+    [int] $ProvWaitTime = 1200000,
 
     [Parameter(Position = 12)]
     [string] $Tags,

--- a/powershell/install/falcon_windows_install.ps1
+++ b/powershell/install/falcon_windows_install.ps1
@@ -589,12 +589,7 @@ process {
                 $message = "Exit code 1244: Falcon was unable to communicate with the CrowdStrike cloud. Please check your installation token and try again."
                 Write-FalconLog 'InstallerProcess' $message
                 throw $message
-            } elseif ($process.ExitCode -eq 1232) {
-                $message = "Exit code 1232: A provisioning/installation token may be required to install the sensor. Please check your installation token settings and try again."
-                Write-FalconLog 'InstallerProcess' $message
-                throw $message
-            }
-            else {
+            } else {
                 if ($process.StandardError) {
                     $errOut = $process.StandardError.ReadToEnd()
                 } else {


### PR DESCRIPTION
Closes #319

Fixes an issue where the $errOut message was null because it didn't exist from the process itself. Now we check and handle that case. Also fixes an issue with the default ProvWaitTime. It was not set in milliseconds, so technically it was waiting for 1.2 seconds instead of the default 20 minutes 😮‍💨 