### PR TITLE
fix(windows_install): remove tolower() from update policy name

### DIFF
--- a/powershell/install/falcon_windows_install.ps1
+++ b/powershell/install/falcon_windows_install.ps1
@@ -482,7 +482,7 @@ process {
     # Get sensor version from policy
     $message = "Retrieving sensor policy details for '$($SensorUpdatePolicyName)'"
     Write-FalconLog 'GetPolicy' $message
-    $filter = "platform_name:'Windows'+name.raw:'$($SensorUpdatePolicyName.ToLower())'"
+    $filter = "platform_name:'Windows'+name.raw:'$($SensorUpdatePolicyName)'"
     $url = "${BaseUrl}/policy/combined/sensor-update/v2?filter=$([System.Web.HttpUtility]::UrlEncode($filter)))"
     $policy_scope = @{
         'Sensor update policies' = @('Read')


### PR DESCRIPTION
This was a regression from a previous commit.

Fixes #322