### PR TITLE
chore: bump to 1.5.1 due to missed files from last release

### DIFF
--- a/bash/containers/falcon-container-sensor-pull/README.md
+++ b/bash/containers/falcon-container-sensor-pull/README.md
@@ -68,7 +68,7 @@ The script supports auto-discovery of the Falcon cloud region. If the cloud regi
 
 ```terminal
 Usage: falcon-container-sensor-pull.sh [options]
-Version: 1.5.0
+Version: 1.5.1
 
 Required Flags:
     -u, --client-id <FALCON_CLIENT_ID>             Falcon API OAUTH Client ID

--- a/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
+++ b/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
@@ -6,7 +6,7 @@ Description: Bash script to copy Falcon DaemonSet Sensor, Container Sensor, Kube
 
 set -e
 
-VERSION="1.5.0"
+VERSION="1.5.1"
 
 usage() {
     echo "Usage: $0 [options]

--- a/bash/install/README.md
+++ b/bash/install/README.md
@@ -75,7 +75,7 @@ The installer is AWS SSM aware, if `FALCON_CLIENT_ID` and `FALCON_CLIENT_SECRET`
 
 ```terminal
 Installs and configures the CrowdStrike Falcon Sensor for Linux.
-Version: 1.5.0
+Version: 1.5.1
 
 The script recognizes the following environmental variables:
 
@@ -160,7 +160,7 @@ Other Options
 To download and run the script:
 
 ```bash
-curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.5.0/bash/install/falcon-linux-install.sh | bash
+curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.5.1/bash/install/falcon-linux-install.sh | bash
 ```
 
 Alternatively, you can run the script by cloning the repo:
@@ -185,7 +185,7 @@ bash falcon-linux-install.sh
 
 ```terminal
 Uninstalls the CrowdStrike Falcon Sensor from Linux operating systems.
-Version: 1.5.0
+Version: 1.5.1
 
 The script recognizes the following environmental variables:
 
@@ -228,7 +228,7 @@ Other Options:
 To download and run the script:
 
 ```bash
-curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.5.0/bash/install/falcon-linux-uninstall.sh | bash
+curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.5.1/bash/install/falcon-linux-uninstall.sh | bash
 ```
 
 Uninstall and remove the host from the Falcon console:
@@ -237,7 +237,7 @@ Uninstall and remove the host from the Falcon console:
 export FALCON_CLIENT_ID="XXXXXXX"
 export FALCON_CLIENT_SECRET="YYYYYYYYY"
 export FALCON_REMOVE_HOST="true"
-curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.5.0/bash/install/falcon-linux-uninstall.sh | bash
+curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.5.1/bash/install/falcon-linux-uninstall.sh | bash
 ```
 
 ## Troubleshooting
@@ -251,5 +251,5 @@ bash -x falcon-linux-install.sh
 or
 
 ```bash
-curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.5.0/bash/install/falcon-linux-install.sh | bash -x
+curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.5.1/bash/install/falcon-linux-install.sh | bash -x
 ```

--- a/bash/install/falcon-linux-install.sh
+++ b/bash/install/falcon-linux-install.sh
@@ -85,7 +85,7 @@ Other Options
 EOF
 }
 
-VERSION="1.5.0"
+VERSION="1.5.1"
 
 main() {
     if [ -n "$1" ]; then

--- a/bash/install/falcon-linux-uninstall.sh
+++ b/bash/install/falcon-linux-uninstall.sh
@@ -43,7 +43,7 @@ Other Options:
 EOF
 }
 
-VERSION="1.5.0"
+VERSION="1.5.1"
 
 main() {
     if [ -n "$1" ]; then

--- a/powershell/install/README.md
+++ b/powershell/install/README.md
@@ -113,7 +113,7 @@ Enable verbose logging
 To download the script:
 
 ```pwsh
-Invoke-WebRequest -Uri https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.4.2/powershell/install/falcon_windows_install.ps1 -OutFile falcon_windows_install.ps1
+Invoke-WebRequest -Uri https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.5.1/powershell/install/falcon_windows_install.ps1 -OutFile falcon_windows_install.ps1
 ```
 
 Basic example that will install the sensor with the provided provisioning token
@@ -175,7 +175,7 @@ Enable verbose logging
 To download the script:
 
 ```pwsh
-Invoke-WebRequest -Uri https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.4.2/powershell/install/falcon_windows_uninstall.ps1 -OutFile falcon_windows_uninstall.ps1
+Invoke-WebRequest -Uri https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.5.1/powershell/install/falcon_windows_uninstall.ps1 -OutFile falcon_windows_uninstall.ps1
 ```
 
 Basic example that will uninstall the sensor with the provided maintenance token

--- a/powershell/install/falcon_windows_install.ps1
+++ b/powershell/install/falcon_windows_install.ps1
@@ -192,7 +192,7 @@ begin {
 
     function Invoke-FalconAuth([hashtable] $WebRequestParams, [string] $BaseUrl, [hashtable] $Body, [string] $FalconCloud) {
         $Headers = @{'Accept' = 'application/json'; 'Content-Type' = 'application/x-www-form-urlencoded'; 'charset' = 'utf-8' }
-        $Headers.Add('User-Agent', 'crowdstrike-falcon-scripts/1.4.2')
+        $Headers.Add('User-Agent', 'crowdstrike-falcon-scripts/1.5.1')
         if ($FalconAccessToken){
             $Headers.Add('Authorization', "bearer $($FalconAccessToken)")
         }

--- a/powershell/install/falcon_windows_uninstall.ps1
+++ b/powershell/install/falcon_windows_uninstall.ps1
@@ -177,7 +177,7 @@ begin {
 
     function Invoke-FalconAuth([hashtable] $WebRequestParams, [string] $BaseUrl, [hashtable] $Body, [string] $FalconCloud) {
         $Headers = @{'Accept' = 'application/json'; 'Content-Type' = 'application/x-www-form-urlencoded'; 'charset' = 'utf-8' }
-        $Headers.Add('User-Agent', 'crowdstrike-falcon-scripts/1.4.2')
+        $Headers.Add('User-Agent', 'crowdstrike-falcon-scripts/1.5.1')
         if ($FalconAccessToken){
             $Headers.Add('Authorization', "bearer $($FalconAccessToken)")
         }

--- a/powershell/migrate/README.md
+++ b/powershell/migrate/README.md
@@ -101,7 +101,7 @@ Enable verbose logging
 To download the script, run the following command:
 
 ```pwsh
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.4.2/powershell/migrate/falcon_windows_migrate.ps1" -OutFile "falcon_windows_migrate.ps1"
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.5.1/powershell/migrate/falcon_windows_migrate.ps1" -OutFile "falcon_windows_migrate.ps1"
 ```
 
 ### Example 1

--- a/powershell/migrate/falcon_windows_migrate.ps1
+++ b/powershell/migrate/falcon_windows_migrate.ps1
@@ -985,7 +985,7 @@ function Get-FalconCloud ([string] $xCsRegion) {
 
 function Invoke-FalconAuth([hashtable] $WebRequestParams, [string] $BaseUrl, [hashtable] $Body, [string] $FalconCloud) {
     $Headers = @{'Accept' = 'application/json'; 'Content-Type' = 'application/x-www-form-urlencoded'; 'charset' = 'utf-8' }
-    $Headers.Add('User-Agent', 'crowdstrike-falcon-scripts/1.4.2')
+    $Headers.Add('User-Agent', 'crowdstrike-falcon-scripts/1.5.1')
     try {
         $response = Invoke-WebRequest @WebRequestParams -Uri "$($BaseUrl)/oauth2/token" -UseBasicParsing -Method 'POST' -Headers $Headers -Body $Body
         $content = ConvertFrom-Json -InputObject $response.Content


### PR DESCRIPTION
This new release adds the missing files from the 1.5.0 release