### PR TITLE
fix(container-pull): hotfix to fix new issue with multi-arch tagging

### DIFF
--- a/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
+++ b/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
@@ -257,7 +257,7 @@ format_tags() {
                 sed -n 's/.*"tags" : \[\(.*\)\].*/\1/p' |
                 awk -F',' -v keyword="$SENSOR_PLATFORM" '{
                     for (i=1; i<=NF; i++) {
-                        if (($i ~ keyword || $i !~ /x86_64|aarch64/) && $i !~ /sha256/) {
+                        if (($i ~ keyword || $i !~ /x86_64|aarch64/) && $i !~ /sha256/ && $i !~ /arm64|amd64/) {
                             print $i
                         }
                     }


### PR DESCRIPTION
Fixes issue with listing tags associated with the new multi-arch image for 7.17