### PR TITLE
fix(container-pull-script): fixes issue with curl errors not being handled properly

### DIFF
--- a/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
+++ b/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
@@ -229,7 +229,7 @@ handle_curl_error() {
     fi
 
     if [ "$1" = "22" ]; then
-        err_msg="Operation with (exit code 22). The requested URL was not found or returned another error with the HTTP error code being 400 or above."
+        err_msg="Operation failed with (exit code 22). The requested URL was not found or returned another error with the HTTP error code being 400 or above."
         die "$err_msg"
     fi
 


### PR DESCRIPTION
Fixes #336 
Adds error handling for curl similar to our other bash installation scripts. Adds a `-f` option to ensure curl fails and returns a code. 