### PR TITLE
fix(container-pull): fixes issue with hardcoded registry for pull token

### DIFF
--- a/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
+++ b/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
@@ -632,7 +632,7 @@ if [ "$PULLTOKEN" ]; then
     PARTIALPULLTOKEN=$(printf "%s:%s" "$ART_USERNAME" "$ART_PASSWORD" | base64 $BASE64_OPT)
     # Generate and display token
     # shellcheck disable=SC2086
-    IMAGE_PULL_TOKEN=$(printf '{"auths": { "registry.crowdstrike.com": { "auth": "%s" } } }' "$PARTIALPULLTOKEN" | base64 $BASE64_OPT)
+    IMAGE_PULL_TOKEN=$(printf '{"auths": { "%s": { "auth": "%s" } } }' "${cs_registry}" "$PARTIALPULLTOKEN" | base64 $BASE64_OPT)
     echo "${IMAGE_PULL_TOKEN}"
     exit 0
 fi


### PR DESCRIPTION
This prevents govcloud users from having a correct pull token generated.