### PR TITLE
fix(container-pull): fixes issue with passing full sensor version

### DIFF
--- a/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
+++ b/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
@@ -676,7 +676,7 @@ if [ "$LISTTAGS" ]; then
 fi
 
 #Get latest sensor version
-LATESTSENSOR=$(list_tags | awk -v RS=" " '{print}' | grep "$SENSOR_VERSION" | grep -o "[0-9a-zA-Z_\.\-]*" | tail -1)
+LATESTSENSOR=$(list_tags | awk -v RS=" " '{print}' | grep -i "$SENSOR_VERSION" | grep -o "[0-9a-zA-Z_\.\-]*" | tail -1)
 
 #Construct full image path
 FULLIMAGEPATH="${REPOSITORY}:${LATESTSENSOR}"


### PR DESCRIPTION
The sensor version gets translated from UPPER:lower before being used. I believe this was to do further processing on it and to ensure some form of consistent format. Either way, the grep of the SENSOR_VERSION variable needs to be case insensitive - allowing a user to pass in a sensor version, whether it be x.y, x.y.z-patch or the full name.

Fixes #340 