### PR TITLE
feat(bash install): add api retrieval for provisioning token

### DIFF
--- a/bash/install/README.md
+++ b/bash/install/README.md
@@ -1,5 +1,13 @@
 # Falcon Linux Bash Installation Scripts
 
+> [!IMPORTANT]
+> **Non-Breaking Change:**
+>
+> API Scope addition: ***Installation Tokens***
+>
+> This scope allows the installation script to retrieve the provisioning token from the API if it is required.
+> For more information, see [Falcon API Permissions](#falcon-api-permissions).
+
 Bash script to install Falcon Sensor through the Falcon APIs on a Linux endpoint. By default,
 this script will install, register the sensor, and start the service. If you would like to simply
 install the sensor without any additional configurations, configure the `FALCON_INSTALL_ONLY`
@@ -26,7 +34,6 @@ To check your version of cURL, run the following command: `curl --version`
   - [Examples](#examples-1)
 - [Troubleshooting](#troubleshooting)
 
-
 ## Falcon API Permissions
 
 API clients are granted one or more API scopes. Scopes allow access to specific CrowdStrike APIs and describe the actions that an API client can perform.
@@ -34,8 +41,16 @@ API clients are granted one or more API scopes. Scopes allow access to specific 
 Ensure the following API scopes are enabled:
 
 - **Sensor Download** [read]
+- **Installation Tokens** [read]
 - (optional) **Sensor update policies** [read]
   > Use this scope when configuring the `FALCON_SENSOR_UPDATE_POLICY_NAME` environment variable.
+- (optional) **Hosts** [write]
+  > Use this scope when configuring the `FALCON_REMOVE_HOST` environment variable for the uninstall script.
+
+> [!IMPORTANT]
+> Installation/provisioning tokens prevent unauthorized hosts from being accidentally or maliciously added to your customer ID (CID).
+> Its best practice to keep these tokens secure which is why the script will attempt to retrieve the token from the API if
+> they are required in your environment.
 
 ## Configuration
 
@@ -119,6 +134,8 @@ Other Options
 
     - FALCON_PROVISIONING_TOKEN         (default: unset)
         The provisioning token to use for installing the sensor.
+        If the provisioning token is unset, the script will attempt to retrieve it from
+        the API using your authentication credentials and CID requirements.
 
     - FALCON_SENSOR_UPDATE_POLICY_NAME  (default: unset)
         The name of the sensor update policy to use for installing the sensor.
@@ -270,13 +287,13 @@ Other Options:
 
 ### Usage
 
-#### To download and run the script directly
+To download and run the script directly
 
 ```bash
 curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.5.4/bash/install/falcon-linux-uninstall.sh | bash
 ```
 
-#### Alternatively, download the script and run it locally
+Alternatively, download the script and run it locally
 
 ```bash
 curl -O https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.5.4/bash/install/falcon-linux-uninstall.sh

--- a/bash/install/README.md
+++ b/bash/install/README.md
@@ -1,13 +1,5 @@
 # Falcon Linux Bash Installation Scripts
 
-> [!IMPORTANT]
-> **Non-Breaking Change:**
->
-> API Scope addition: ***Installation Tokens***
->
-> This scope allows the installation script to retrieve the provisioning token from the API if it is required.
-> For more information, see [Falcon API Permissions](#falcon-api-permissions).
-
 Bash script to install Falcon Sensor through the Falcon APIs on a Linux endpoint. By default,
 this script will install, register the sensor, and start the service. If you would like to simply
 install the sensor without any additional configurations, configure the `FALCON_INSTALL_ONLY`
@@ -41,16 +33,12 @@ API clients are granted one or more API scopes. Scopes allow access to specific 
 Ensure the following API scopes are enabled:
 
 - **Sensor Download** [read]
-- **Installation Tokens** [read]
+- (optional) **Installation Tokens** [read]
+  > This scope allows the installation script to retrieve a provisioning token from the API, but only if installation tokens are required in your environment.
 - (optional) **Sensor update policies** [read]
   > Use this scope when configuring the `FALCON_SENSOR_UPDATE_POLICY_NAME` environment variable.
 - (optional) **Hosts** [write]
   > Use this scope when configuring the `FALCON_REMOVE_HOST` environment variable for the uninstall script.
-
-> [!IMPORTANT]
-> Installation/provisioning tokens prevent unauthorized hosts from being accidentally or maliciously added to your customer ID (CID).
-> Its best practice to keep these tokens secure which is why the script will attempt to retrieve the token from the API if
-> they are required in your environment.
 
 ## Configuration
 

--- a/bash/install/falcon-linux-install.sh
+++ b/bash/install/falcon-linux-install.sh
@@ -34,7 +34,7 @@ Other Options
     - FALCON_PROVISIONING_TOKEN         (default: unset)
         The provisioning token to use for installing the sensor.
         If the provisioning token is unset, the script will attempt to retrieve it from
-        the API using your authentication credentials and CID requirements.
+        the API using your authentication credentials and token requirements.
 
     - FALCON_SENSOR_UPDATE_POLICY_NAME  (default: unset)
         The name of the sensor update policy to use for installing the sensor.

--- a/bash/install/falcon-linux-install.sh
+++ b/bash/install/falcon-linux-install.sh
@@ -33,6 +33,8 @@ Other Options
 
     - FALCON_PROVISIONING_TOKEN         (default: unset)
         The provisioning token to use for installing the sensor.
+        If the provisioning token is unset, the script will attempt to retrieve it from
+        the API using your authentication credentials and CID requirements.
 
     - FALCON_SENSOR_UPDATE_POLICY_NAME  (default: unset)
         The name of the sensor update policy to use for installing the sensor.
@@ -138,7 +140,10 @@ main() {
 cs_sensor_register() {
     # Get the falcon cid
     cs_falcon_cid="$(get_falcon_cid)"
-
+    # If cs_falcon_token is not set, try getting it from api
+    if [ -z "${cs_falcon_token}" ]; then
+        cs_falcon_token="$(get_provisioning_token)"
+    fi
     # add the cid to the params
     cs_falcon_args=--cid="${cs_falcon_cid}"
     if [ -n "${cs_falcon_token}" ]; then
@@ -721,6 +726,36 @@ get_oauth_token() {
     fi
 
     rm "${response_headers}"
+}
+
+get_provisioning_token() {
+    local check_settings is_required token_query token_value token_id token_result
+    # First, let's check if installation tokens are required
+    check_settings=$(curl_command "https://$(cs_cloud)/installation-tokens/entities/customer-settings/v1")
+    handle_curl_error $?
+
+    if echo "$check_settings" | grep "authorization failed"; then
+        echo "Access denied: Skipping installation token retrieval."
+        echo "Please make sure that your Falcon API credentials allow access to installation tokens (scope Installation Tokens [read])"
+    fi
+
+    is_required=$(echo "$check_settings" | json_value "tokens_required" | xargs)
+    if [ "$is_required" = "true" ]; then
+        # Get the token ID
+        token_query=$(curl_command "https://$(cs_cloud)/installation-tokens/queries/tokens/v1")
+        token_id=$(echo "$token_query" | tr -d '\n" ' | awk -F'[][]' '{print $2}' | cut -d',' -f1)
+        if [ -z "$token_id" ]; then
+            die "No installation token found in a required token environment."
+        fi
+
+        # Get the token value from ID
+        token_result=$(curl_command "https://$(cs_cloud)/installation-tokens/entities/tokens/v1?ids=$token_id")
+        token_value=$(echo "$token_result" | json_value "value" | xargs)
+        if [ -z "$token_value" ]; then
+            die "Could not obtain installation token value."
+        fi
+    fi
+    echo "$token_value"
 }
 
 get_falcon_cid() {


### PR DESCRIPTION
Fixes #354 

This PR introduces the ability to retrieve your provisioning token from the API, the same we can retrieve the CID. Per security reasons, it may not be logical to expose your installation tokens in plain-text, so this way can do it "behind" the scene.

The way this works is (assuming you do not pass in a provisioning-token):
1. We check your existing token settings
1. If installation tokens are required in your CID:
    1. We grab a token ID
    1. We grab the value from the token ID
1. We set that as the provisioning-token   

So we only do something if tokens are required, which is the key here. 