### PR TITLE
fix(pwsh): add missing '/' to error message for oauth2

### DIFF
--- a/powershell/install/falcon_windows_install.ps1
+++ b/powershell/install/falcon_windows_install.ps1
@@ -249,7 +249,7 @@ begin {
                     }
                 }
                 else {
-                    $message = "Received a $($response.StatusCode) response from $($BaseUrl)oauth2/token. Please check your credentials and try again. Error: $($response.StatusDescription)"
+                    $message = "Received a $($response.StatusCode) response from $($BaseUrl)/oauth2/token. Please check your credentials and try again. Error: $($response.StatusDescription)"
                     Write-FalconLog -Source 'Invoke-FalconAuth' -Message $message
                     throw $message
                 }

--- a/powershell/migrate/falcon_windows_migrate.ps1
+++ b/powershell/migrate/falcon_windows_migrate.ps1
@@ -1033,7 +1033,7 @@ function Invoke-FalconAuth([hashtable] $WebRequestParams, [string] $BaseUrl, [ha
             }
         }
         else {
-            $message = "Received a $($response.StatusCode) response from $($BaseUrl)oauth2/token. Please check your credentials and try again. Error: $($response.StatusDescription)"
+            $message = "Received a $($response.StatusCode) response from $($BaseUrl)/oauth2/token. Please check your credentials and try again. Error: $($response.StatusDescription)"
             Write-FalconLog -Source 'Invoke-FalconAuth' -Message $message
             throw $message
         }


### PR DESCRIPTION
Fixes #363 