### PR TITLE
fix(container-pull): support skopeo and get-image-path

### DIFF
--- a/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
+++ b/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
@@ -699,7 +699,7 @@ esac
 
 CONTAINER_TOOL=$(command -v "$CONTAINER_TOOL")
 
-if grep -qw "skopeo" "$CONTAINER_TOOL" && [ -z "${COPY}" ] && [ -z "${LISTTAGS}" ]; then
+if grep -qw "skopeo" "$CONTAINER_TOOL" && [ -z "${COPY}" ] && [ -z "${LISTTAGS}" ] && [ -z "${GETIMAGEPATH}" ]; then
     echo "-c, --copy <REGISTRY/NAMESPACE> must also be set when using skopeo as a runtime"
     exit 1
 fi


### PR DESCRIPTION
Hi!

I noticed that I was always setting this -c parameter, even though it doesn't make sense. After I removed it, I received an error, which I think is a bug.

Cheers
Ruwen