### PR TITLE
fix(bash install): add support for CentOS Stream

### DIFF
--- a/bash/install/falcon-linux-install.sh
+++ b/bash/install/falcon-linux-install.sh
@@ -393,7 +393,7 @@ os_install_package() {
     }
     # shellcheck disable=SC2221,SC2222
     case "${os_name}" in
-        Amazon | CentOS | Oracle | RHEL | Rocky | AlmaLinux | SLES)
+        Amazon | CentOS* | Oracle | RHEL | Rocky | AlmaLinux | SLES)
             rpm_install_package "$pkg"
             ;;
         Debian)
@@ -838,7 +838,7 @@ cs_os_name=$(
         Amazon)
             echo "Amazon Linux"
             ;;
-        CentOS | Oracle | RHEL | Rocky | AlmaLinux)
+        CentOS* | Oracle | RHEL | Rocky | AlmaLinux)
             echo "*RHEL*"
             ;;
         Debian)


### PR DESCRIPTION
Fixes #412

This PR adds support for CentOS Stream Linux distros