### PR TITLE
fix(bash install): add package lock checks to prevent premature failure

### DIFF
--- a/bash/install/falcon-linux-install.sh
+++ b/bash/install/falcon-linux-install.sh
@@ -373,11 +373,43 @@ cs_sensor_download() {
     echo "$installer"
 }
 
+check_package_manager_lock() {
+    local lock_file="$1"
+    local lock_type="$2"
+    local timeout=300 interval=5 elapsed=0
+
+    # If no lock file specified, skip the check
+    if [ -z "$lock_file" ]; then
+        return 0
+    fi
+
+    while lsof -w "$lock_file" >/dev/null 2>&1; do
+        if [ $elapsed -eq 0 ]; then
+            echo ""
+            echo "Package manager is locked. Waiting up to ${timeout} seconds for lock to be released..."
+        fi
+
+        if [ $elapsed -ge $timeout ]; then
+            echo "Timed out waiting for ${lock_type} lock to be released after ${timeout} seconds."
+            echo "You may need to manually investigate processes locking ${lock_file}:"
+            lsof -w "$lock_file" || true
+            die "Installation aborted due to package manager lock timeout."
+        fi
+
+        sleep $interval
+        elapsed=$((elapsed + interval))
+        echo -n "."
+    done
+}
+
 os_install_package() {
     local pkg="$1"
 
     rpm_install_package() {
         local pkg="$1"
+
+        # Check for RPM lock before proceeding
+        check_package_manager_lock "/var/lib/rpm/.rpm.lock" "RPM"
 
         cs_falcon_gpg_import
 
@@ -397,9 +429,14 @@ os_install_package() {
             rpm_install_package "$pkg"
             ;;
         Debian)
+            # Check for Debian lock before proceeding
+            check_package_manager_lock "/var/lib/dpkg/lock" "APT"
             DEBIAN_FRONTEND=noninteractive apt-get -qq install -y "$pkg" >/dev/null
             ;;
         Ubuntu)
+            # Check for Ubuntu lock before proceeding
+            check_package_manager_lock "/var/lib/dpkg/lock" "APT"
+
             # If this is ubuntu 14, we need to use dpkg instead
             if [ "${cs_os_version}" -eq 14 ]; then
                 DEBIAN_FRONTEND=noninteractive dpkg -i "$pkg" >/dev/null 2>&1 || true

--- a/bash/install/falcon-linux-uninstall.sh
+++ b/bash/install/falcon-linux-uninstall.sh
@@ -397,24 +397,6 @@ get_aid() {
 #------Start of the script------#
 set -e
 
-os_name=$(
-    # returns either: Amazon, Ubuntu, CentOS, RHEL, or SLES
-    # lsb_release is not always present
-    name=$(cat /etc/*release | grep ^NAME= | awk -F'=' '{ print $2 }' | sed "s/\"//g;s/Red Hat.*/RHEL/g;s/ Linux$//g;s/ GNU\/Linux$//g;s/Oracle.*/Oracle/g;s/Amazon.*/Amazon/g")
-    if [ -z "$name" ]; then
-        if lsb_release -s -i | grep -q ^RedHat; then
-            name="RHEL"
-        elif [ -f /usr/bin/lsb_release ]; then
-            name=$(/usr/bin/lsb_release -s -i)
-        fi
-    fi
-    if [ -z "$name" ]; then
-        die "Cannot recognise operating system"
-    fi
-
-    echo "$name"
-)
-
 cs_falcon_cloud=$(
     if [ -n "$FALCON_CLOUD" ]; then
         echo "$FALCON_CLOUD"

--- a/bash/install/falcon-linux-uninstall.sh
+++ b/bash/install/falcon-linux-uninstall.sh
@@ -81,22 +81,14 @@ main() {
 }
 
 check_package_manager_lock() {
-    local lock_file lock_type timeout=300 interval=5 elapsed=0
+    lock_file="/var/lib/rpm/.rpm.lock"
+    lock_type="RPM"
+    local timeout=300 interval=5 elapsed=0
 
-    case "${os_name}" in
-        Amazon | CentOS* | Oracle | RHEL | Rocky | AlmaLinux | SLES)
-            lock_file="/var/lib/rpm/.rpm.lock"
-            lock_type="RPM"
-            ;;
-        Debian | Ubuntu)
-            lock_file="/var/lib/dpkg/lock"
-            lock_type="APT"
-            ;;
-        *)
-            # No lock checking for unknown systems
-            return 0
-            ;;
-    esac
+    if type dpkg >/dev/null 2>&1; then
+        lock_file="/var/lib/dpkg/lock"
+        lock_type="DPKG"
+    fi
 
     while lsof -w "$lock_file" >/dev/null 2>&1; do
         if [ $elapsed -eq 0 ]; then
@@ -113,7 +105,7 @@ check_package_manager_lock() {
 
         sleep $interval
         elapsed=$((elapsed + interval))
-        echo -n "."
+        echo "Retrying again in ${interval} seconds..."
     done
 }
 


### PR DESCRIPTION
fixes 374

This PR introduces a method of ensuring that we don't perform package management operations if the package manager is currently locked due to other operations happening.