### PR TITLE
feat: allow user-agent string to be customizable

### DIFF
--- a/bash/install/falcon-linux-install.sh
+++ b/bash/install/falcon-linux-install.sh
@@ -91,6 +91,10 @@ Other Options
         To prepare the sensor to be used in a golden image.
         Accepted values are ['true', 'false'].
 
+    - USER_AGENT                        (default: unset)
+        User agent string to append to the User-Agent header when making
+        requests to the CrowdStrike API.
+
 This script recognizes the following argument:
     -h, --help
         Print this help message and exit.
@@ -724,6 +728,14 @@ get_falcon_credentials() {
     fi
 }
 
+get_user_agent() {
+    local user_agent="crowdstrike-falcon-scripts/$VERSION"
+    if [ -n "$USER_AGENT" ]; then
+        user_agent="${user_agent} ${USER_AGENT}"
+    fi
+    echo "$user_agent"
+}
+
 get_oauth_token() {
     # Get credentials first
     get_falcon_credentials
@@ -735,7 +747,7 @@ get_oauth_token() {
             token_result=$(echo "client_id=$cs_falcon_client_id&client_secret=$cs_falcon_client_secret" |
                 curl -X POST -s -x "$proxy" -L "https://$(cs_cloud)/oauth2/token" \
                     -H 'Content-Type: application/x-www-form-urlencoded; charset=utf-8' \
-                    -H "User-Agent: crowdstrike-falcon-scripts/$VERSION" \
+                    -H "User-Agent: $(get_user_agent)" \
                     --dump-header "${response_headers}" \
                     --data @-)
 

--- a/bash/install/falcon-linux-uninstall.sh
+++ b/bash/install/falcon-linux-uninstall.sh
@@ -44,6 +44,10 @@ Other Options:
     - FALCON_APP                        (default: unset)
         The proxy port for the sensor to use when communicating with CrowdStrike.
 
+    - USER_AGENT                        (default: unset)
+        User agent string to append to the User-Agent header when making
+        requests to the CrowdStrike API.
+
 This script recognizes the following argument:
     -h, --help
         Print this help message and exit.
@@ -347,6 +351,14 @@ get_falcon_credentials() {
     fi
 }
 
+get_user_agent() {
+    local user_agent="crowdstrike-falcon-scripts/$VERSION"
+    if [ -n "$USER_AGENT" ]; then
+        user_agent="${user_agent} ${USER_AGENT}"
+    fi
+    echo "$user_agent"
+}
+
 get_oauth_token() {
     # Get credentials first
     get_falcon_credentials
@@ -358,7 +370,7 @@ get_oauth_token() {
             token_result=$(echo "client_id=$cs_falcon_client_id&client_secret=$cs_falcon_client_secret" |
                 curl -X POST -s -x "$proxy" -L "https://$(cs_cloud)/oauth2/token" \
                     -H 'Content-Type: application/x-www-form-urlencoded; charset=utf-8' \
-                    -H "User-Agent: crowdstrike-falcon-scripts/$VERSION" \
+                    -H "User-Agent: $(get_user_agent)" \
                     --dump-header "${response_headers}" \
                     --data @-)
 

--- a/powershell/install/falcon_windows_install.ps1
+++ b/powershell/install/falcon_windows_install.ps1
@@ -51,6 +51,8 @@ The proxy port for the sensor to use when communicating with CrowdStrike [defaul
 .PARAMETER ProxyDisable
 By default, the Falcon sensor for Windows automatically attempts to use any available proxy connections when it connects to the CrowdStrike cloud.
 This parameter forces the sensor to skip those attempts and ignore any proxy configuration, including Windows Proxy Auto Detection.
+.PARAMETER UserAgent
+User agent string to append to the User-Agent header when making requests to the CrowdStrike API.
 .PARAMETER Verbose
 Enable verbose logging
 
@@ -127,7 +129,10 @@ param(
     [switch] $GetAccessToken,
 
     [Parameter(Position = 18)]
-    [string] $FalconAccessToken
+    [string] $FalconAccessToken,
+
+    [Parameter(Position = 19)]
+    [string] $UserAgent
 )
 begin {
     if ($PSVersionTable.PSVersion -lt '3.0')
@@ -141,6 +146,13 @@ begin {
         $PSScriptRoot
     }
 
+    $ScriptVersion = "1.7.4"
+    $BaseUserAgent = "crowdstrike-falcon-scripts/$ScriptVersion"
+    $FullUserAgent = if ($UserAgent) {
+        "$BaseUserAgent $UserAgent"
+    } else {
+        $BaseUserAgent
+    }
 
     function Write-FalconLog ([string] $Source, [string] $Message, [bool] $stdout = $true) {
         $Content = @(Get-Date -Format 'yyyy-MM-dd hh:MM:ss')
@@ -192,7 +204,7 @@ begin {
 
     function Invoke-FalconAuth([hashtable] $WebRequestParams, [string] $BaseUrl, [hashtable] $Body, [string] $FalconCloud) {
         $Headers = @{'Accept' = 'application/json'; 'Content-Type' = 'application/x-www-form-urlencoded'; 'charset' = 'utf-8' }
-        $Headers.Add('User-Agent', 'crowdstrike-falcon-scripts/1.7.4')
+        $Headers.Add('User-Agent', $FullUserAgent)
         if ($FalconAccessToken) {
             $Headers.Add('Authorization', "bearer $($FalconAccessToken)")
         }

--- a/powershell/install/falcon_windows_uninstall.ps1
+++ b/powershell/install/falcon_windows_uninstall.ps1
@@ -43,6 +43,8 @@ Member CID, used only in multi-CID ("Falcon Flight Control") configurations and 
 The proxy host for the sensor to use when communicating with CrowdStrike [default: $null]
 .PARAMETER ProxyPort
 The proxy port for the sensor to use when communicating with CrowdStrike [default: $null]
+.PARAMETER UserAgent
+User agent string to append to the User-Agent header when making requests to the CrowdStrike API.
 .PARAMETER Verbose
 Enable verbose logging
 
@@ -107,7 +109,10 @@ param(
     [switch] $GetAccessToken,
 
     [Parameter(Position = 15)]
-    [string] $FalconAccessToken
+    [string] $FalconAccessToken,
+
+    [Parameter(Position = 16)]
+    [string] $UserAgent
 )
 begin {
 
@@ -125,6 +130,14 @@ begin {
     }
     else {
         $PSScriptRoot
+    }
+
+    $ScriptVersion = "1.7.4"
+    $BaseUserAgent = "crowdstrike-falcon-scripts/$ScriptVersion"
+    $FullUserAgent = if ($UserAgent) {
+        "$BaseUserAgent $UserAgent"
+    } else {
+        $BaseUserAgent
     }
 
     function Write-FalconLog ([string] $Source, [string] $Message, [bool] $stdout = $true) {
@@ -177,7 +190,7 @@ begin {
 
     function Invoke-FalconAuth([hashtable] $WebRequestParams, [string] $BaseUrl, [hashtable] $Body, [string] $FalconCloud) {
         $Headers = @{'Accept' = 'application/json'; 'Content-Type' = 'application/x-www-form-urlencoded'; 'charset' = 'utf-8' }
-        $Headers.Add('User-Agent', 'crowdstrike-falcon-scripts/1.7.4')
+        $Headers.Add('User-Agent', $FullUserAgent)
         if ($FalconAccessToken) {
             $Headers.Add('Authorization', "bearer $($FalconAccessToken)")
         }


### PR DESCRIPTION
Closes #415 

This PR introduces a new variable that can allow for appending a custom user-agent string to use for insights metrics. While mostly aimed for internal usage, this follow RFC convention by appending the provided user-agent string to the default user-agent string.