### PR TITLE
ci: remove debian-11 from test matrix

### DIFF
--- a/.github/workflows/bash_install.yml
+++ b/.github/workflows/bash_install.yml
@@ -79,11 +79,6 @@ jobs:
             image_arch: arm64
             image_name: RHEL-9.?.?_HVM-*
             instance_type: t4g.micro
-          - distro: debian-11
-            image_owner: '136693071363'
-            image_arch: x86_64
-            image_name: debian-11-amd64-*
-            instance_type: t2.micro
         collection_role:
           - bash_install
 

--- a/.github/workflows/bash_install_decrement.yml
+++ b/.github/workflows/bash_install_decrement.yml
@@ -79,11 +79,6 @@ jobs:
             image_arch: arm64
             image_name: RHEL-9.?.?_HVM-*
             instance_type: t4g.micro
-          - distro: debian-11
-            image_owner: '136693071363'
-            image_arch: x86_64
-            image_name: debian-11-amd64-*
-            instance_type: t2.micro
         collection_role:
           - bash_install_decrement
 

--- a/.github/workflows/bash_install_only.yml
+++ b/.github/workflows/bash_install_only.yml
@@ -79,11 +79,6 @@ jobs:
             image_arch: arm64
             image_name: RHEL-9.?.?_HVM-*
             instance_type: t4g.micro
-          - distro: debian-11
-            image_owner: '136693071363'
-            image_arch: x86_64
-            image_name: debian-11-amd64-*
-            instance_type: t2.micro
         collection_role:
           - bash_install_only
 

--- a/.github/workflows/bash_install_policy.yml
+++ b/.github/workflows/bash_install_policy.yml
@@ -79,11 +79,6 @@ jobs:
             image_arch: arm64
             image_name: RHEL-9.?.?_HVM-*
             instance_type: t4g.micro
-          - distro: debian-11
-            image_owner: '136693071363'
-            image_arch: x86_64
-            image_name: debian-11-amd64-*
-            instance_type: t2.micro
         collection_role:
           - bash_install_policy
 

--- a/.github/workflows/bash_migrate.yml
+++ b/.github/workflows/bash_migrate.yml
@@ -79,11 +79,6 @@ jobs:
             image_arch: arm64
             image_name: RHEL-9.?.?_HVM-*
             instance_type: t4g.micro
-          - distro: debian-11
-            image_owner: '136693071363'
-            image_arch: x86_64
-            image_name: debian-11-amd64-*
-            instance_type: t2.micro
         collection_role:
           - bash_migrate
 


### PR DESCRIPTION
Debian 11 is now in LTS mode with limited support and the backports are decommissioned