### PR TITLE
Fix PowerShell null exception handling in migration script

### DIFF
--- a/powershell/migrate/falcon_windows_migrate.ps1
+++ b/powershell/migrate/falcon_windows_migrate.ps1
@@ -432,7 +432,12 @@ function Invoke-FalconUninstall ([hashtable] $WebRequestParams, [string] $Uninst
     }
     catch {
         Write-VerboseLog -VerboseInput $_.Exception -PreMessage 'Invoke-FalconUninstall - CAUGHT EXCEPTION - $_.Exception:'
-        $message = "Error uninstalling Falcon Sensor: $($_.Exception.Message)"
+        $errorMessage = if ($_.Exception -and $_.Exception.Message) {
+            $_.Exception.Message
+        } else {
+            "Unknown error occurred"
+        }
+        $message = "Error uninstalling Falcon Sensor: $errorMessage"
         throw $message
     }
 }
@@ -615,7 +620,12 @@ function Invoke-FalconInstall ([hashtable] $WebRequestParams, [string] $InstallP
         Write-FalconLog -Source 'Invoke-FalconInstall' -Message $Message
     }
     catch {
-        $message = "Error installing Falcon Sensor: $($_.Exception.Message)"
+        $errorMessage = if ($_.Exception -and $_.Exception.Message) {
+            $_.Exception.Message
+        } else {
+            "Unknown error occurred"
+        }
+        $message = "Error installing Falcon Sensor: $errorMessage"
         throw $message
     }
 }


### PR DESCRIPTION
## Summary
Fixes two catch blocks in `falcon_windows_migrate.ps1` that cause secondary null reference exceptions in certain environments like Microsoft Intune.

## Problem
Users reported PowerShell script failures with the error "You cannot call a method on a null-valued expression" when running in Intune environments. The error occurs because two catch blocks directly access `$_.Exception.Message` without checking if the Exception object is null first.

## Solution
Added proper null checking to both problematic catch blocks:
- `Invoke-FalconUninstall` function (line 435)
- `Invoke-FalconInstall` function (line 618)

Both now follow the safe pattern already used elsewhere in the same script.

## Changes
```powershell
# Before (vulnerable)
catch {
    $message = "Error installing Falcon Sensor: $($_.Exception.Message)"
    throw $message
}

# After (safe)
catch {
    $errorMessage = if ($_.Exception -and $_.Exception.Message) {
        $_.Exception.Message
    } else {
        "Unknown error occurred"
    }
    $message = "Error installing Falcon Sensor: $errorMessage"
    throw $message
}
```

## Testing
- PowerShell syntax validation: ✅ PASSED
- PSScriptAnalyzer linting: ✅ PASSED (only pre-existing warnings unrelated to changes)
- Exception handling pattern verified

## Related
- Fixes #451