### PR TITLE
feat(bash): remove FALCON_TRACE and add FALCON_SENSOR_CLOUD support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 .vagrant
 .vscode
 Vagrantfile
+
+# local testing
+tests/

--- a/bash/install/README.md
+++ b/bash/install/README.md
@@ -163,9 +163,10 @@ Other Options
         For sensor backend.
         Accepted values are values: [auto|bpf|kernel].
 
-    - FALCON_TRACE                      (default: none)
-        To configure the trace level.
-        Accepted values are [none|err|warn|info|debug]
+    - FALCON_SENSOR_CLOUD               (default: unset)
+        To pin the cloud region for unified sensor installations.
+        This allows specifying the cloud region for unified sensors at installation time.
+        Accepted values are [us-1|us-2|eu-1|us-gov-1|us-gov-2].
 
     - FALCON_UNINSTALL                  (default: false)
         To uninstall the falcon sensor.

--- a/bash/install/falcon-linux-install.sh
+++ b/bash/install/falcon-linux-install.sh
@@ -63,9 +63,10 @@ Other Options
         For sensor backend.
         Accepted values are values: [auto|bpf|kernel].
 
-    - FALCON_TRACE                      (default: none)
-        To configure the trace level.
-        Accepted values are [none|err|warn|info|debug]
+    - FALCON_SENSOR_CLOUD               (default: unset)
+        To pin the cloud region for unified sensor installations.
+        This allows specifying the cloud region for unified sensors at installation time.
+        Accepted values are [us-1|us-2|eu-1|us-gov-1|us-gov-2].
 
     - FALCON_UNINSTALL                  (default: false)
         To uninstall the falcon sensor.
@@ -193,10 +194,10 @@ cs_sensor_register() {
         cs_falconctl_opt_backend=--backend="${cs_falcon_backend}"
         cs_falcon_args="$cs_falcon_args $cs_falconctl_opt_backend"
     fi
-    # add the trace level to the params
-    if [ -n "${cs_falcon_trace}" ]; then
-        cs_falconctl_opt_trace=--trace="${cs_falcon_trace}"
-        cs_falcon_args="$cs_falcon_args $cs_falconctl_opt_trace"
+    # add the cloud region to the params for unified sensors
+    if [ -n "${cs_falcon_sensor_cloud}" ]; then
+        cs_falconctl_opt_cloud=--cloud="${cs_falcon_sensor_cloud}"
+        cs_falcon_args="$cs_falcon_args $cs_falconctl_opt_cloud"
     fi
     # run the configuration command
     # shellcheck disable=SC2086
@@ -1042,26 +1043,26 @@ if [ -n "$FALCON_BACKEND" ]; then
     )
 fi
 
-if [ -n "$FALCON_TRACE" ]; then
-    cs_falcon_trace=$(
-        case "${FALCON_TRACE}" in
-            none)
-                echo "none"
+if [ -n "$FALCON_SENSOR_CLOUD" ]; then
+    cs_falcon_sensor_cloud=$(
+        case "${FALCON_SENSOR_CLOUD}" in
+            us-1)
+                echo "us-1"
                 ;;
-            err)
-                echo "err"
+            us-2)
+                echo "us-2"
                 ;;
-            warn)
-                echo "warn"
+            eu-1)
+                echo "eu-1"
                 ;;
-            info)
-                echo "info"
+            us-gov-1)
+                echo "us-gov-1"
                 ;;
-            debug)
-                echo "debug"
+            us-gov-2)
+                echo "us-gov-2"
                 ;;
             *)
-                die "Unrecognized TRACE: ${FALCON_TRACE} value must be one of : [none|err|warn|info|debug]"
+                die "Unrecognized SENSOR_CLOUD: ${FALCON_SENSOR_CLOUD} value must be one of : [us-1|us-2|eu-1|us-gov-1|us-gov-2]"
                 ;;
         esac
     )

--- a/bash/migrate/README.md
+++ b/bash/migrate/README.md
@@ -178,9 +178,10 @@ Other Options
         For sensor backend.
         Accepted values are values: [auto|bpf|kernel].
 
-    - FALCON_TRACE                      (default: none)
-        To configure the trace level.
-        Accepted values are [none|err|warn|info|debug]
+    - FALCON_SENSOR_CLOUD               (default: unset)
+        To pin the cloud region for unified sensor installations.
+        This allows specifying the cloud region for unified sensors at installation time.
+        Accepted values are [us-1|us-2|eu-1|us-gov-1|us-gov-2].
 
     - ALLOW_LEGACY_CURL                 (default: false)
         To use the legacy version of curl; version < 7.55.0.

--- a/bash/migrate/falcon-linux-migrate.sh
+++ b/bash/migrate/falcon-linux-migrate.sh
@@ -105,9 +105,10 @@ Other Options
         For sensor backend.
         Accepted values are values: [auto|bpf|kernel].
 
-    - FALCON_TRACE                      (default: none)
-        To configure the trace level.
-        Accepted values are [none|err|warn|info|debug]
+    - FALCON_SENSOR_CLOUD               (default: unset)
+        To pin the cloud region for unified sensor installations.
+        This allows specifying the cloud region for unified sensors at installation time.
+        Accepted values are [us-1|us-2|eu-1|us-gov-1|us-gov-2].
 
     - ALLOW_LEGACY_CURL                 (default: false)
         To use the legacy version of curl; version < 7.55.0.
@@ -510,10 +511,10 @@ cs_sensor_register() {
         cs_falconctl_opt_backend=--backend="${cs_falcon_backend}"
         cs_falcon_args="$cs_falcon_args $cs_falconctl_opt_backend"
     fi
-    # add the trace level to the params
-    if [ -n "${cs_falcon_trace}" ]; then
-        cs_falconctl_opt_trace=--trace="${cs_falcon_trace}"
-        cs_falcon_args="$cs_falcon_args $cs_falconctl_opt_trace"
+    # add the cloud region to the params for unified sensors
+    if [ -n "${cs_falcon_sensor_cloud}" ]; then
+        cs_falconctl_opt_cloud=--cloud="${cs_falcon_sensor_cloud}"
+        cs_falcon_args="$cs_falcon_args $cs_falconctl_opt_cloud"
     fi
     # run the configuration command
     # shellcheck disable=SC2086
@@ -1277,26 +1278,26 @@ if [ -n "$FALCON_BACKEND" ]; then
     )
 fi
 
-if [ -n "$FALCON_TRACE" ]; then
-    cs_falcon_trace=$(
-        case "${FALCON_TRACE}" in
-            none)
-                echo "none"
+if [ -n "$FALCON_SENSOR_CLOUD" ]; then
+    cs_falcon_sensor_cloud=$(
+        case "${FALCON_SENSOR_CLOUD}" in
+            us-1)
+                echo "us-1"
                 ;;
-            err)
-                echo "err"
+            us-2)
+                echo "us-2"
                 ;;
-            warn)
-                echo "warn"
+            eu-1)
+                echo "eu-1"
                 ;;
-            info)
-                echo "info"
+            us-gov-1)
+                echo "us-gov-1"
                 ;;
-            debug)
-                echo "debug"
+            us-gov-2)
+                echo "us-gov-2"
                 ;;
             *)
-                die "Unrecognized TRACE: ${FALCON_TRACE} value must be one of : [none|err|warn|info|debug]"
+                die "Unrecognized SENSOR_CLOUD: ${FALCON_SENSOR_CLOUD} value must be one of : [us-1|us-2|eu-1|us-gov-1|us-gov-2]"
                 ;;
         esac
     )


### PR DESCRIPTION
## Summary

This PR implements the requested changes from issue #454:

### Add unified sensor cloud support
- Add FALCON_SENSOR_CLOUD environment variable for pinning cloud regions
- Support cloud regions: `us-1`, `us-2`, `eu-1`, `us-gov-1`, `us-gov-2`
- Add validation function for cloud region values
- Pass `--cloud` parameter to falconctl during sensor registration
- Enable cloud region specification for unified sensors at installation time

Closes #454