### PR TITLE
fix(powershell): enable access token variable assignment (#440)

### DIFF
--- a/powershell/install/falcon_windows_install.ps1
+++ b/powershell/install/falcon_windows_install.ps1
@@ -220,11 +220,6 @@ begin {
                     throw $message
                 }
 
-                if ($GetAccessToken -eq $true) {
-                    Write-Output $content.access_token | out-host
-                    exit 0
-                }
-
                 $Headers.Add('Authorization', "bearer $($content.access_token)")
             }
             catch {
@@ -468,6 +463,13 @@ process {
         }
 
         $BaseUrl, $Headers = Invoke-FalconAuth -WebRequestParams $WebRequestParams -BaseUrl $BaseUrl -Body $Body -FalconCloud $FalconCloud
+
+        # Check if we just need the token
+        if ($GetAccessToken -eq $true) {
+            $token = $Headers['Authorization'] -replace '^bearer\s+', ''
+            Write-Output $token
+            exit 0
+        }
         $Headers['Content-Type'] = 'application/json'
         $WebRequestParams.Add('Headers', $Headers)
     }

--- a/powershell/install/falcon_windows_uninstall.ps1
+++ b/powershell/install/falcon_windows_uninstall.ps1
@@ -206,11 +206,6 @@ begin {
                     throw $Message
                 }
 
-                if ($GetAccessToken -eq $true) {
-                    Write-Output $content.access_token | out-host
-                    exit
-                }
-
                 $Headers.Add('Authorization', "bearer $($content.access_token)")
             }
             catch {
@@ -450,6 +445,13 @@ process {
         }
 
         $BaseUrl, $Headers = Invoke-FalconAuth -WebRequestParams $WebRequestParams -BaseUrl $BaseUrl -Body $Body -FalconCloud $FalconCloud
+
+        # Check if we just need the token
+        if ($GetAccessToken -eq $true) {
+            $token = $Headers['Authorization'] -replace '^bearer\s+', ''
+            Write-Output $token
+            exit 0
+        }
         $Headers['Content-Type'] = 'application/json'
         $WebRequestParams.Add('Headers', $Headers)
     }


### PR DESCRIPTION

- Fixes issue where access tokens could not be captured in variables due to `| out-host` 
- Removes problematic output redirection that bypassed PowerShell's output stream
- Moves GetAccessToken logic to main process flow for better code organization

Closes #440