### PR TITLE
fix(container-pull): remove KPA sensor type support

### DIFF
--- a/.github/workflows/container_sensor_pull.yml
+++ b/.github/workflows/container_sensor_pull.yml
@@ -39,8 +39,6 @@ jobs:
             cli_arg: '-n'
           - type: falcon-kac
             cli_arg: '--kubernetes-admission-controller'
-          - type: kpagent
-            cli_arg: '--kubernetes-protection-agent'
 
     steps:
       - name: Check out code

--- a/bash/containers/falcon-container-sensor-pull/DEPRECATION.md
+++ b/bash/containers/falcon-container-sensor-pull/DEPRECATION.md
@@ -6,7 +6,7 @@ The following deprecations will be introduced in version 2.0.0 of the Falcon Con
 
 1. **Environment Variable Deprecation** : The `SENSORTYPE` environment variable will be deprecated and replaced by `SENSOR_TYPE`. This update is intended to increase readability and maintain consistency in our environment variable naming convention.
 
-1. **Command Option Deprecation** : The command line options `-n, --node`, `--kubernetes-admission-controller`, and `--kubernetes-protection-agent` will be deprecated and replaced by a single option `-t, --type`. The new `-t, --type` option will allow you to specify the sensor type in a more straightforward and simplified manner.
+1. **Command Option Deprecation** : The command line options `-n, --node` and `--kubernetes-admission-controller` will be deprecated and replaced by a single option `-t, --type`. The new `-t, --type` option will allow you to specify the sensor type in a more straightforward and simplified manner.
 
 While these changes will be officially introduced in version 2.0.0, we will continue to support the deprecated environment variable and command options until that release. We strongly encourage you to adapt your usage to include the new `SENSOR_TYPE` environment variable and `-t, --type` command option to ensure a smooth transition when version 2.0.0 is released.
 

--- a/bash/containers/falcon-container-sensor-pull/README.md
+++ b/bash/containers/falcon-container-sensor-pull/README.md
@@ -70,10 +70,6 @@ To check your version of cURL, run the following command: `curl --version`
 - **falcon-sensor | falcon-sensor-regional | falcon-container | falcon-container-regional | falcon-kac | falcon-kac-regional | falcon-imageanalyzer | falcon-jobcontroller | falcon-registryassessmentexecutor**
   - `Sensor Download (read)`
   - `Falcon Images Download (read)`
-- **kpagent**
-  - `Sensor Download (read)`
-  - `Falcon Images Download (read)`
-  - `Kubernetes Protection (read)`
 - **falcon-snapshot**
   - `Sensor Download (read)`
   - `Snapshot Scanner Image Download (read)`
@@ -116,7 +112,6 @@ Optional Flags:
                                                    falcon-kac
                                                    falcon-snapshot
                                                    falcon-imageanalyzer
-                                                   kpagent
                                                    fcs
                                                    falcon-jobcontroller
                                                    falcon-registryassessmentexecutor
@@ -151,7 +146,7 @@ Help Options:
 | `-c`, `--copy <REGISTRY/NAMESPACE>`            | `$COPY`                 | `None` (Optional)             | Registry you want to copy the sensor image to. Example: `myregistry.com/mynamespace`. <br> *\*By default, the image name and tag are appended. Use `--copy-omit-image-name` and/or `--copy-custom-tag` to change that behavior.*           |
 | `-v`, `--version <SENSOR_VERSION>`             | `$SENSOR_VERSION`       | `None` (Optional)             | Specify sensor version to retrieve from the registry                                                                                                                                                                                                     |
 | `-p`, `--platform <SENSOR_PLATFORM>`           | `$SENSOR_PLATFORM`      | `None` (Optional)             | Specify sensor platform to retrieve from the registry                                                                                                                                                                                                    |
-| `-t`, `--type <SENSOR_TYPE>`                   | `$SENSOR_TYPE`          | `falcon-container` (Optional) | Specify which sensor to download [`falcon-container`, `falcon-sensor`, `falcon-sensor-regional`, `falcon-kac`, `falcon-snapshot`, `falcon-imageanalyzer`, `kpagent`, `fcs`, `falcon-jobcontroller`, `falcon-registryassessmentexecutor`] ([see more details below](#sensor-types)) |
+| `-t`, `--type <SENSOR_TYPE>`                   | `$SENSOR_TYPE`          | `falcon-container` (Optional) | Specify which sensor to download [`falcon-container`, `falcon-sensor`, `falcon-sensor-regional`, `falcon-kac`, `falcon-snapshot`, `falcon-imageanalyzer`, `fcs`, `falcon-jobcontroller`, `falcon-registryassessmentexecutor`] ([see more details below](#sensor-types)) |
 | `--runtime`                                    | `$CONTAINER_TOOL`       | `docker` (Optional)           | Use a different container runtime [docker, podman, skopeo]. **Default is Docker**.                                                                                                                                                                       |
 | `--dump-credentials`                           | `$CREDS`                | `False` (Optional)            | Print registry credentials to stdout to copy/paste into container tools                                                                                                                                                                                  |
 | `--get-image-path`                             | N/A                     | `None`                        | Get the full image path including the registry, repository, and latest tag for the specified `SENSOR_TYPE`.                                                                                                                                              |
@@ -184,7 +179,6 @@ The following sensor types are available to download:
 | `falcon-kac`                        | The Falcon Kubernetes Admission Controller            |
 | `falcon-snapshot`                   | The Falcon Snapshot scanner                           |
 | `falcon-imageanalyzer`              | The Falcon Image Assessment at Runtime                |
-| `kpagent`                           | The Falcon Kubernetes Protection Agent                |
 | `fcs`                               | The Falcon Cloud Security CLI tool                    |
 | `falcon-jobcontroller`              | The Self Hosted Registry Assessment Jobs Controller   |
 | `falcon-registryassessmentexecutor` | The Self Hosted Registry Assessment Executor          |

--- a/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
+++ b/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 : <<'#DESCRIPTION#'
 File: falcon-container-sensor-pull.sh
-Description: Bash script to copy Falcon DaemonSet Sensor, Container Sensor, Kubernetes Admission Controller or Kubernetes Protection Agent images from CrowdStrike Container Registry.
+Description: Bash script to copy Falcon DaemonSet Sensor, Container Sensor, or Kubernetes Admission Controller images from CrowdStrike Container Registry.
 #DESCRIPTION#
 
 set -e
@@ -36,7 +36,6 @@ Optional Flags:
                                                    falcon-kac-regional
                                                    falcon-snapshot
                                                    falcon-imageanalyzer
-                                                   kpagent
                                                    fcs
                                                    falcon-jobcontroller
                                                    falcon-registryassessmentexecutor
@@ -189,12 +188,6 @@ while [ $# != 0 ]; do
                 SENSOR_TYPE="falcon-kac"
             fi
             ;;
-        --kubernetes-protection-agent)
-            if [ -n "${1}" ]; then
-                deprecated "--kubernetes-protection-agent"
-                SENSOR_TYPE="kpagent"
-            fi
-            ;;
         -t | --type)
             if [ -n "${2}" ]; then
                 SENSOR_TYPE="${2}"
@@ -305,11 +298,11 @@ fetch_tags() {
 }
 
 format_tags() {
-    # Formats tags and handles sorting for KPA
+    # Formats tags and handles sorting for non-standard images
     local all_tags=$1
 
     case "${SENSOR_TYPE}" in
-        "kpagent" | "falcon-snapshot" | "falcon-imageanalyzer" | "fcs" | "falcon-jobcontroller" | "falcon-registryassessmentexecutor")
+        "falcon-snapshot" | "falcon-imageanalyzer" | "fcs" | "falcon-jobcontroller" | "falcon-registryassessmentexecutor")
             echo "$all_tags" |
                 sed -n 's/.*"tags" : \[\(.*\)\].*/\1/p' |
                 tr -d '"' | tr ',' '\n' |
@@ -449,9 +442,6 @@ display_api_scopes() {
         falcon-sensor | falcon-sensor-regional | falcon-container | falcon-container-regional | falcon-kac | falcon-kac-regional | falcon-imageanalyzer | falcon-jobcontroller | falcon-registryassessmentexecutor)
             echo "Sensor Download [read], Falcon Images Download [read]"
             ;;
-        kpagent)
-            echo "Sensor Download [read], Falcon Images Download [read], Kubernetes Protection [read]"
-            ;;
         falcon-snapshot)
             echo "Sensor Download [read], Snapshot Scanner Image Download [read]"
             ;;
@@ -554,7 +544,7 @@ fi
 
 # Check if SENSOR_TYPE is set to a valid value
 case "${SENSOR_TYPE}" in
-    falcon-container | falcon-container-regional | falcon-sensor | falcon-sensor-regional | falcon-kac | falcon-kac-regional | falcon-snapshot | falcon-imageanalyzer | kpagent | fcs | falcon-jobcontroller | falcon-registryassessmentexecutor) ;;
+    falcon-container | falcon-container-regional | falcon-sensor | falcon-sensor-regional | falcon-kac | falcon-kac-regional | falcon-snapshot | falcon-imageanalyzer | fcs | falcon-jobcontroller | falcon-registryassessmentexecutor) ;;
     *) die """
     Unrecognized sensor type: ${SENSOR_TYPE}
     Valid values are:
@@ -566,7 +556,6 @@ case "${SENSOR_TYPE}" in
         falcon-kac-regional
         falcon-snapshot
         falcon-imageanalyzer
-        kpagent
         fcs
         falcon-jobcontroller
         falcon-registryassessmentexecutor""" ;;
@@ -689,11 +678,7 @@ cs_falcon_cid_with_checksum=$(
 cs_falcon_cid=$(echo "$cs_falcon_cid_with_checksum" | cut -d'-' -f1 | tr '[:upper:]' '[:lower:]')
 
 if [ "$GETCID" ]; then
-    if [ "${SENSOR_TYPE}" = "kpagent" ]; then
-        echo "${cs_falcon_cid}"
-    else
-        echo "${cs_falcon_cid_with_checksum}"
-    fi
+    echo "${cs_falcon_cid_with_checksum}"
     exit 0
 fi
 
@@ -745,13 +730,6 @@ elif [ "${SENSOR_TYPE}" = "falcon-imageanalyzer" ]; then
     # overrides for Image Analyzer
     IMAGE_NAME="falcon-imageanalyzer"
     repository_name="$BUILD_STAGE/falcon-imageanalyzer"
-elif [ "${SENSOR_TYPE}" = "kpagent" ]; then
-    # overrides for KPA
-    ART_USERNAME="kp-$cs_falcon_cid"
-    IMAGE_NAME="kpagent"
-    repository_name="kpagent"
-    registry_type="kubernetes-protection"
-    registry_opts="kubernetes_protection"
 elif [ "${SENSOR_TYPE}" = "fcs" ]; then
     # overrides for FCS
     ART_USERNAME="fh-$cs_falcon_cid"
@@ -781,15 +759,9 @@ elif [ "${SENSOR_TYPE}" = "falcon-registryassessmentexecutor" ]; then
 fi
 
 #Set Docker token using the BEARER token captured earlier
-if [ "${SENSOR_TYPE}" = "kpagent" ]; then
-    raw_docker_api_token=$(curl_command "$cs_falcon_oauth_token" "https://$(cs_cloud)/$registry_type/entities/integration/agent/v1?cluster_name=clustername&is_self_managed_cluster=true")
-    handle_curl_error $?
-    docker_api_token=$(echo "$raw_docker_api_token" | awk '/dockerAPIToken:/ {print $2}')
-else
-    raw_docker_api_token=$(curl_command "$cs_falcon_oauth_token" "https://$(cs_cloud)/$registry_type/entities/image-registry-credentials/v1")
-    handle_curl_error $?
-    docker_api_token=$(echo "$raw_docker_api_token" | json_value "token")
-fi
+raw_docker_api_token=$(curl_command "$cs_falcon_oauth_token" "https://$(cs_cloud)/$registry_type/entities/image-registry-credentials/v1")
+handle_curl_error $?
+docker_api_token=$(echo "$raw_docker_api_token" | json_value "token")
 
 ART_PASSWORD=$(echo "$docker_api_token" | sed 's/ *$//g' | sed 's/^ *//g')
 if [ -z "$ART_PASSWORD" ]; then


### PR DESCRIPTION
## Summary

- Removes KPA (Kubernetes Protection Agent) sensor type from the container pull script
- KPA has reached end-of-support and has been replaced by KAC (Kubernetes Admission Controller)
- Reference: [Tech Alert - Falcon Kubernetes Protection Agent End of Support](https://supportportal.crowdstrike.com/s/article/Tech-Alert-Update-Falcon-Kubernetes-Protection-Agent-End-of-Support-and-Transition-to-Falcon-Kubernetes-Admission-Controller)

## Changes

- **falcon-container-sensor-pull.sh**: Removed all KPA-specific code including CLI flag, sensor type validation, registry configuration, and API token retrieval logic
- **README.md**: Removed KPA from API scopes, sensor types list, and sensor types table
- **DEPRECATION.md**: Removed `--kubernetes-protection-agent` from deprecated flags
- **container_sensor_pull.yml**: Removed KPA test matrix entry

Closes #473