### PR TITLE
chore: bump v1.12.0

### DIFF
--- a/bash/containers/falcon-container-sensor-pull/README.md
+++ b/bash/containers/falcon-container-sensor-pull/README.md
@@ -89,7 +89,7 @@ The script supports auto-discovery of the Falcon cloud region. If the cloud regi
 
 ```terminal
 Usage: falcon-container-sensor-pull.sh [options]
-Version: 1.11.1
+Version: 1.12.0
 
 Required Flags:
     -u, --client-id <FALCON_CLIENT_ID>             Falcon API OAUTH Client ID

--- a/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
+++ b/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
@@ -6,7 +6,7 @@ Description: Bash script to copy Falcon DaemonSet Sensor, Container Sensor, or K
 
 set -e
 
-VERSION="1.11.1"
+VERSION="1.12.0"
 
 usage() {
     echo "Usage: $0 [options]

--- a/bash/install/README.md
+++ b/bash/install/README.md
@@ -106,7 +106,7 @@ The installer is AWS SSM aware, if `FALCON_CLIENT_ID` and `FALCON_CLIENT_SECRET`
 Usage: falcon-linux-install.sh [-h|--help]
 
 Installs and configures the CrowdStrike Falcon Sensor for Linux.
-Version: 1.11.1
+Version: 1.12.0
 
 This script recognizes the following environmental variables:
 
@@ -209,7 +209,7 @@ To download and run the script directly:
 ```bash
 export FALCON_CLIENT_ID="XXXXXXX"
 export FALCON_CLIENT_SECRET="YYYYYYYYY"
-curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.11.1/bash/install/falcon-linux-install.sh | bash
+curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.12.0/bash/install/falcon-linux-install.sh | bash
 ```
 
 Alternatively, download the script and run it locally:
@@ -217,7 +217,7 @@ Alternatively, download the script and run it locally:
 ```bash
 export FALCON_CLIENT_ID="XXXXXXX"
 export FALCON_CLIENT_SECRET="YYYYYYYYY"
-curl -O https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.11.1/bash/install/falcon-linux-install.sh
+curl -O https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.12.0/bash/install/falcon-linux-install.sh
 bash falcon-linux-install.sh
 ```
 
@@ -234,7 +234,7 @@ FALCON_CLIENT_ID="XXXXXXX" FALCON_CLIENT_SECRET="YYYYYYYYY" bash falcon-linux-in
 ```bash
 export FALCON_CLIENT_ID="XXXXXXX"
 export FALCON_CLIENT_SECRET="YYYYYYYYY"
-curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.11.1/bash/install/falcon-linux-install.sh | bash
+curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.12.0/bash/install/falcon-linux-install.sh | bash
 ```
 
 #### Install the Falcon Sensor with the previous version (n-1)
@@ -243,7 +243,7 @@ curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.11.1/bas
 export FALCON_CLIENT_ID="XXXXXXX"
 export FALCON_CLIENT_SECRET="YYYYYYYYY"
 export FALCON_SENSOR_VERSION_DECREMENT=1
-curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.11.1/bash/install/falcon-linux-install.sh | bash
+curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.12.0/bash/install/falcon-linux-install.sh | bash
 ```
 
 #### Create a Golden Image
@@ -252,7 +252,7 @@ curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.11.1/bas
 export FALCON_CLIENT_ID="XXXXXXX"
 export FALCON_CLIENT_SECRET="YYYYYYYYY"
 export PREP_GOLDEN_IMAGE="true"
-curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.11.1/bash/install/falcon-linux-install.sh | bash
+curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.12.0/bash/install/falcon-linux-install.sh | bash
 ```
 
 ## Uninstall Script
@@ -261,7 +261,7 @@ curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.11.1/bas
 Usage: falcon-linux-uninstall.sh [-h|--help]
 
 Uninstalls the CrowdStrike Falcon Sensor from Linux operating systems.
-Version: 1.11.1
+Version: 1.12.0
 
 This script recognizes the following environmental variables:
 
@@ -318,13 +318,13 @@ This script recognizes the following argument:
 To download and run the script directly
 
 ```bash
-curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.11.1/bash/install/falcon-linux-uninstall.sh | bash
+curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.12.0/bash/install/falcon-linux-uninstall.sh | bash
 ```
 
 Alternatively, download the script and run it locally
 
 ```bash
-curl -O https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.11.1/bash/install/falcon-linux-uninstall.sh
+curl -O https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.12.0/bash/install/falcon-linux-uninstall.sh
 bash falcon-linux-uninstall.sh
 ```
 
@@ -333,7 +333,7 @@ bash falcon-linux-uninstall.sh
 #### Uninstall the Falcon Sensor
 
 ```bash
-curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.11.1/bash/install/falcon-linux-uninstall.sh | bash
+curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.12.0/bash/install/falcon-linux-uninstall.sh | bash
 ```
 
 ## Troubleshooting
@@ -347,5 +347,5 @@ bash -x falcon-linux-install.sh
 or
 
 ```bash
-curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.11.1/bash/install/falcon-linux-install.sh | bash -x
+curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.12.0/bash/install/falcon-linux-install.sh | bash -x
 ```

--- a/bash/install/falcon-linux-install.sh
+++ b/bash/install/falcon-linux-install.sh
@@ -104,7 +104,7 @@ This script recognizes the following argument:
 EOF
 }
 
-VERSION="1.11.1"
+VERSION="1.12.0"
 
 # If -h or --help is passed, print the usage and exit
 if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then

--- a/bash/install/falcon-linux-uninstall.sh
+++ b/bash/install/falcon-linux-uninstall.sh
@@ -60,7 +60,7 @@ This script recognizes the following argument:
 EOF
 }
 
-VERSION="1.11.1"
+VERSION="1.12.0"
 
 # If -h or --help is passed, print the usage and exit
 if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then

--- a/bash/migrate/README.md
+++ b/bash/migrate/README.md
@@ -84,7 +84,7 @@ export [OLD|NEW]FALCON_CLOUD="us-gov-1"
 Usage: falcon-linux-migrate.sh [-h|--help]
 
 Migrates the Falcon sensor to another Falcon CID.
-Version: 1.11.1
+Version: 1.12.0
 
 This script recognizes the following environmental variables:
 
@@ -206,7 +206,7 @@ export OLD_FALCON_CLOUD="us-1"
 export NEW_FALCON_CLIENT_ID="ZZZZZZZ"
 export NEW_FALCON_CLIENT_SECRET="WWWWWWW"
 export NEW_FALCON_CLOUD="us-2"
-curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.11.1/bash/migrate/falcon-linux-migrate.sh | sudo bash
+curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.12.0/bash/migrate/falcon-linux-migrate.sh | sudo bash
 ```
 
 #### Migrate a sensor to EU-1 with removal from old console
@@ -219,7 +219,7 @@ export NEW_FALCON_CLIENT_ID="ZZZZZZZ"
 export NEW_FALCON_CLIENT_SECRET="WWWWWWW"
 export NEW_FALCON_CLOUD="eu-1"
 export FALCON_REMOVE_HOST="true"
-curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.11.1/bash/migrate/falcon-linux-migrate.sh | sudo bash
+curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.12.0/bash/migrate/falcon-linux-migrate.sh | sudo bash
 ```
 
 #### Migrate a sensor with custom tags
@@ -231,7 +231,7 @@ export NEW_FALCON_CLIENT_ID="ZZZZZZZ"
 export NEW_FALCON_CLIENT_SECRET="WWWWWWW"
 export FALCON_TAGS="department/it,location/hq"
 export FALCON_GROUPING_TAGS="environment/production,criticality/high"
-curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.11.1/bash/migrate/falcon-linux-migrate.sh | sudo bash
+curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.12.0/bash/migrate/falcon-linux-migrate.sh | sudo bash
 ```
 
 #### Migrate a sensor from one CID to another within the same cloud
@@ -243,7 +243,7 @@ export OLD_FALCON_CLOUD="us-1"
 export NEW_FALCON_CLIENT_ID="ZZZZZZZ"
 export NEW_FALCON_CLIENT_SECRET="WWWWWWW"
 export NEW_FALCON_CLOUD="us-1"
-curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.11.1/bash/migrate/falcon-linux-migrate.sh | sudo bash
+curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.12.0/bash/migrate/falcon-linux-migrate.sh | sudo bash
 ```
 
 ## Troubleshooting
@@ -257,7 +257,7 @@ bash -x falcon-linux-migrate.sh
 or
 
 ```bash
-curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.11.1/bash/migrate/falcon-linux-migrate.sh | bash -x
+curl -L https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.12.0/bash/migrate/falcon-linux-migrate.sh | bash -x
 ```
 
 The script creates a log file at the location specified by `LOG_PATH` (defaults to `/tmp`) with the name format `falcon_migration_YYYYMMDD_HHMMSS.log`. This log contains detailed information about each step of the migration process.

--- a/bash/migrate/falcon-linux-migrate.sh
+++ b/bash/migrate/falcon-linux-migrate.sh
@@ -3,7 +3,7 @@
 # Bash script to migrate Falcon sensor to another falcon CID.
 #
 
-VERSION="1.11.1"
+VERSION="1.12.0"
 
 print_usage() {
     cat <<EOF

--- a/powershell/install/README.md
+++ b/powershell/install/README.md
@@ -122,7 +122,7 @@ Enable verbose logging
 To download the script:
 
 ```pwsh
-Invoke-WebRequest -Uri https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.11.1/powershell/install/falcon_windows_install.ps1 -OutFile falcon_windows_install.ps1
+Invoke-WebRequest -Uri https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.12.0/powershell/install/falcon_windows_install.ps1 -OutFile falcon_windows_install.ps1
 ```
 
 Basic example that will install the sensor with the provided provisioning token
@@ -184,7 +184,7 @@ Enable verbose logging
 To download the script:
 
 ```pwsh
-Invoke-WebRequest -Uri https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.11.1/powershell/install/falcon_windows_uninstall.ps1 -OutFile falcon_windows_uninstall.ps1
+Invoke-WebRequest -Uri https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.12.0/powershell/install/falcon_windows_uninstall.ps1 -OutFile falcon_windows_uninstall.ps1
 ```
 
 Basic example that will uninstall the sensor with the provided maintenance token

--- a/powershell/install/falcon_windows_install.ps1
+++ b/powershell/install/falcon_windows_install.ps1
@@ -146,7 +146,7 @@ begin {
         $PSScriptRoot
     }
 
-    $ScriptVersion = "1.11.1"
+    $ScriptVersion = "1.12.0"
     $BaseUserAgent = "crowdstrike-falcon-scripts/$ScriptVersion"
     $FullUserAgent = if ($UserAgent) {
         "$BaseUserAgent $UserAgent"

--- a/powershell/install/falcon_windows_uninstall.ps1
+++ b/powershell/install/falcon_windows_uninstall.ps1
@@ -132,7 +132,7 @@ begin {
         $PSScriptRoot
     }
 
-    $ScriptVersion = "1.11.1"
+    $ScriptVersion = "1.12.0"
     $BaseUserAgent = "crowdstrike-falcon-scripts/$ScriptVersion"
     $FullUserAgent = if ($UserAgent) {
         "$BaseUserAgent $UserAgent"

--- a/powershell/migrate/README.md
+++ b/powershell/migrate/README.md
@@ -109,7 +109,7 @@ Enable verbose logging
 To download the script, run the following command:
 
 ```pwsh
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.11.1/powershell/migrate/falcon_windows_migrate.ps1" -OutFile "falcon_windows_migrate.ps1"
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/crowdstrike/falcon-scripts/v1.12.0/powershell/migrate/falcon_windows_migrate.ps1" -OutFile "falcon_windows_migrate.ps1"
 ```
 
 ### Example 1

--- a/powershell/migrate/falcon_windows_migrate.ps1
+++ b/powershell/migrate/falcon_windows_migrate.ps1
@@ -1092,7 +1092,7 @@ if (!(Test-FalconCredential $OldFalconClientId $OldFalconClientSecret)) {
     throw $message
 }
 
-$ScriptVersion = "1.11.1"
+$ScriptVersion = "1.12.0"
 $BaseUserAgent = "crowdstrike-falcon-scripts/$ScriptVersion pwsh-migrate"
 $FullUserAgent = if ($UserAgent) {
     "$BaseUserAgent $UserAgent"


### PR DESCRIPTION
Bumps version strings from v1.11.1 to v1.12.0 across all scripts and READMEs (12 files) to prepare the v1.12.0 release.

Two changes have landed on main since v1.11.1:

- feat(container-pull): add unified image support for `falcon-imageanalyzer` (#489)
- fix(sensors): add error message when tamper protection blocks uninstall (#492)

The feature addition warrants a minor version bump.