### PR TITLE
fix(container-pull): add missing account param in registry token URL

### DIFF
--- a/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
+++ b/bash/containers/falcon-container-sensor-pull/falcon-container-sensor-pull.sh
@@ -288,7 +288,7 @@ curl_command() {
 
 fetch_tags() {
     bearer_result=$(echo "-u $ART_USERNAME:$ART_PASSWORD" |
-        curl -s -L "https://$cs_registry/v2/token?=$ART_USERNAME&scope=repository:$registry_opts/$repository_name:pull&service=$cs_registry" -K-)
+        curl -s -L "https://$cs_registry/v2/token?account=$ART_USERNAME&scope=repository:$registry_opts/$repository_name:pull&service=$cs_registry" -K-)
     handle_curl_error $?
     registry_bearer=$(echo "$bearer_result" | json_value "token" | sed 's/ *$//g' | sed 's/^ *//g')
     # Check if registry_bearer is not empty
@@ -859,9 +859,9 @@ if [ "${ERROR}" = "true" ]; then
 fi
 
 #Get latest sensor version
-set +e  # Temporarily disable exit-on-error for version matching
+set +e # Temporarily disable exit-on-error for version matching
 LATESTSENSOR=$(match_sensor_version "$SENSOR_VERSION")
-set -e  # Re-enable exit-on-error
+set -e # Re-enable exit-on-error
 
 # Check if version matching was successful
 if [ -z "$LATESTSENSOR" ]; then


### PR DESCRIPTION
The `/v2/token` endpoint URL in `fetch_tags()` was missing the `account` query parameter name, producing `?=username` instead of `?account=username`. The laggar registry (us-gov-1) started rejecting this malformed URL with a 500 error — commercial registries still tolerate it, but the URL was never spec-correct.

Tested against both `registry.laggar.gcw.crowdstrike.com` and `registry.crowdstrike.com` to confirm the fix works on gov and commercial.